### PR TITLE
fix: Create suppressions for each reporter-specific vulnerability ID

### DIFF
--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/core/Suppression.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/core/Suppression.kt
@@ -13,20 +13,14 @@ import dev.vulnlog.cli.model.suppress.SuppressionOutput
 import dev.vulnlog.cli.model.suppress.SuppressionVuln
 import java.time.LocalDate
 
-data class SuppressionFilter(
-    val filter: VulnlogFilter = VulnlogFilter(),
-    val today: LocalDate = LocalDate.now(),
-)
-
 /**
- * Collects and groups suppressed vulnerabilities from the provided VulnlogFile based on the specified suppression filter criteria.
+ * Collects and filters suppressed vulnerabilities from a given Vulnlog file based on the specified suppression
+ * filter criteria. The vulnerabilities are grouped by their reporter type.
  *
- * This method processes the vulnerabilities by applying the filter configuration, including release, tags, resolution, and reporter type.
- * Suppressed vulnerabilities are extracted from the reports, filtered for their expiration status, and grouped by the reporter type.
- *
- * @param vulnlogFile The VulnlogFile containing vulnerabilities to be processed.
- * @param filter The suppression filter that defines filtering criteria such as release, tags, reporter, and the current date for expiration checks.
- * @return A map where the keys are the reporter types, and the values are lists of suppressed vulnerabilities that match the filter criteria.
+ * @param vulnlogFile The Vulnlog file containing vulnerability records to analyze.
+ * @param filter The suppression filter to apply for selecting and grouping vulnerabilities.
+ * @return A map where the keys are the reporter types, and the values are lists of suppressed vulnerabilities
+ *         associated with each reporter.
  */
 fun collectSuppressedVulnerabilities(
     vulnlogFile: VulnlogFile,
@@ -34,37 +28,45 @@ fun collectSuppressedVulnerabilities(
 ): Map<ReporterType, List<SuppressedVulnerability>> =
     vulnlogFile.vulnerabilities
         .asSequence()
-        .applyFilter(filter.filter)
-        .flatMap { vulnerability -> collectEligibleReports(vulnerability, filter.today) }
-        .groupBy { it.reports.reporter }
+        .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today) }
+        .applyFilter(filter)
+        .groupBy { it.reporter }
         .filter { filter.filter.reporter == null || it.key == filter.filter.reporter }
 
-private fun collectEligibleReports(
+private fun explodeAndMapToSuppressedVulnerabilities(
     vulnerability: VulnerabilityEntry,
     today: LocalDate,
 ): List<SuppressedVulnerability> {
-    if (vulnerability.resolution != null) {
+    if (vulnerability.verdict is Verdict.Affected && vulnerability.resolution != null) {
         return emptyList()
     }
-
-    val eligibleReports =
-        when (vulnerability.verdict) {
-            is Verdict.NotAffected, is Verdict.RiskAcceptable -> vulnerability.reports
-            else ->
-                vulnerability.reports
-                    .filter { it.suppress != null }
-                    .filter { it.suppress?.expiresAt?.isAfter(today) ?: true }
+    return vulnerability.reports.flatMap { report ->
+        if (!isReportEligible(vulnerability.verdict, report.suppress, today)) {
+            return@flatMap emptyList()
         }
-
-    return eligibleReports.map { report ->
-        SuppressedVulnerability(
-            id = vulnerability.id,
-            releases = vulnerability.releases,
-            reports = report,
-            tags = vulnerability.tags,
-            analysis = vulnerability.analysis ?: "",
-        )
+        val ids: Collection<VulnId> = report.vulnIds.ifEmpty { listOf(vulnerability.id) }
+        ids.map { id ->
+            SuppressedVulnerability(
+                id = id,
+                releases = vulnerability.releases,
+                reporter = report.reporter,
+                expiresAt = report.suppress?.expiresAt,
+                tags = vulnerability.tags,
+                analysis = vulnerability.analysis ?: "",
+            )
+        }
     }
+}
+
+private fun isReportEligible(
+    verdict: Verdict,
+    suppress: dev.vulnlog.cli.model.Suppression?,
+    today: LocalDate,
+): Boolean {
+    if (verdict is Verdict.NotAffected) return true
+    if (suppress == null) return false
+    val expiresAt = suppress.expiresAt ?: return true
+    return !expiresAt.isBefore(today)
 }
 
 /**
@@ -120,14 +122,13 @@ private fun createGenericSuppression(
 ): SuppressionOutput {
     val entries =
         suppressions
-            .flatMap { entry ->
-                resolveVulnIds(entry, defaults).map { id ->
-                    SuppressionVuln.GenericSuppressionEntry(
-                        id = id,
-                        expiresAt = entry.reports.suppress?.expiresAt,
-                        reason = entry.analysis,
-                    )
-                }
+            .filter { suppression -> suppression.id::class in defaults.vulnIdTypes }
+            .map { suppression ->
+                SuppressionVuln.GenericSuppressionEntry(
+                    id = suppression.id,
+                    expiresAt = suppression.expiresAt,
+                    reason = suppression.analysis,
+                )
             }.toSet()
     return SuppressionOutput.GenericSuppression(
         fileName = defaults.reporter.name.lowercase() + ".generic.json",
@@ -136,50 +137,35 @@ private fun createGenericSuppression(
 }
 
 private fun createTrivySuppression(
-    defaults: Suppressable,
+    defaults: Suppressable.NativeFormat.Trivy,
     suppressions: List<SuppressedVulnerability>,
 ): SuppressionOutput {
     val entries =
         suppressions
-            .flatMap { entry ->
-                resolveVulnIds(entry, defaults).map { id ->
-                    SuppressionVuln.TrivySuppressionEntry(
-                        id = id,
-                        expiresAt = entry.reports.suppress?.expiresAt,
-                        reason = entry.analysis,
-                    )
-                }
+            .filter { suppression -> suppression.id::class in defaults.vulnIdTypes }
+            .map { suppression ->
+                SuppressionVuln.TrivySuppressionEntry(
+                    id = suppression.id,
+                    expiresAt = suppression.expiresAt,
+                    reason = suppression.analysis,
+                )
             }.toSet()
     return SuppressionOutput.TrivySuppression(entries = entries)
 }
 
 private fun createSnykSuppression(
-    defaults: Suppressable,
+    defaults: Suppressable.NativeFormat.Snyk,
     suppressions: List<SuppressedVulnerability>,
 ): SuppressionOutput {
     val entries =
         suppressions
-            .flatMap { entry ->
-                resolveVulnIds(entry, defaults).map { id ->
-                    SuppressionVuln.SnykSuppressionEntry(
-                        id = id,
-                        expiresAt = entry.reports.suppress?.expiresAt,
-                        reason = entry.analysis,
-                    )
-                }
+            .filter { suppression -> suppression.id::class in defaults.vulnIdTypes }
+            .map { suppression ->
+                SuppressionVuln.SnykSuppressionEntry(
+                    id = suppression.id,
+                    expiresAt = suppression.expiresAt,
+                    reason = suppression.analysis,
+                )
             }.toSet()
     return SuppressionOutput.SnykSuppression(entries = entries)
-}
-
-private fun resolveVulnIds(
-    entry: SuppressedVulnerability,
-    defaults: Suppressable,
-): Set<VulnId> {
-    val reporterSpecific =
-        entry.reports.vulnIds
-            .filter { it::class in defaults.vulnIdTypes }
-            .toSet()
-    return reporterSpecific.ifEmpty {
-        if (entry.id::class in defaults.vulnIdTypes) setOf(entry.id) else emptySet()
-    }
 }

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/core/VulnlogFilter.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/core/VulnlogFilter.kt
@@ -4,6 +4,9 @@ import dev.vulnlog.cli.model.Release
 import dev.vulnlog.cli.model.ReporterType
 import dev.vulnlog.cli.model.Tag
 import dev.vulnlog.cli.model.VulnerabilityEntry
+import dev.vulnlog.cli.model.suppress.SuppressedVulnerability
+import java.time.LocalDate
+import kotlin.sequences.filter
 
 data class VulnlogFilter(
     val releases: Set<Release> = emptySet(),
@@ -11,7 +14,17 @@ data class VulnlogFilter(
     val reporter: ReporterType? = null,
 )
 
+data class SuppressionFilter(
+    val filter: VulnlogFilter = VulnlogFilter(),
+    val today: LocalDate = LocalDate.now(),
+)
+
 fun Sequence<VulnerabilityEntry>.applyFilter(filter: VulnlogFilter): Sequence<VulnerabilityEntry> =
     this
         .filter { filter.releases.isEmpty() || it.releases.any { release -> release in filter.releases } }
         .filter { filter.tags.isEmpty() || filter.tags.any { tag -> it.tags.contains(tag) } }
+
+fun Sequence<SuppressedVulnerability>.applyFilter(filter: SuppressionFilter): Sequence<SuppressedVulnerability> =
+    this
+        .filter { filter.filter.releases.isEmpty() || it.releases.any { release -> release in filter.filter.releases } }
+        .filter { filter.filter.tags.isEmpty() || filter.filter.tags.any { tag -> it.tags.contains(tag) } }

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/model/suppress/SuppressedVulnerability.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/model/suppress/SuppressedVulnerability.kt
@@ -1,7 +1,7 @@
 package dev.vulnlog.cli.model.suppress
 
 import dev.vulnlog.cli.model.Release
-import dev.vulnlog.cli.model.ReportEntry
+import dev.vulnlog.cli.model.ReporterType
 import dev.vulnlog.cli.model.Tag
 import dev.vulnlog.cli.model.VulnId
 import java.time.LocalDate
@@ -9,7 +9,8 @@ import java.time.LocalDate
 data class SuppressedVulnerability(
     val id: VulnId,
     val releases: List<Release>,
-    val reports: ReportEntry,
+    val reporter: ReporterType,
+    val expiresAt: LocalDate?,
     val tags: List<Tag> = emptyList(),
     val analysis: String,
 )

--- a/next/cli-app/src/test/kotlin/dev/vulnlog/cli/core/SuppressionTest.kt
+++ b/next/cli-app/src/test/kotlin/dev/vulnlog/cli/core/SuppressionTest.kt
@@ -69,12 +69,14 @@ private fun vulnerability(
 
 private fun suppressedVuln(
     id: VulnId = VulnId.Cve("CVE-2024-0001"),
-    report: ReportEntry = trivyReport(),
+    reporter: ReporterType = ReporterType.TRIVY,
+    expiresAt: LocalDate? = null,
     analysis: String = "not affected",
 ) = SuppressedVulnerability(
     id = id,
     releases = listOf(releaseV1),
-    reports = report,
+    reporter = reporter,
+    expiresAt = expiresAt,
     analysis = analysis,
 )
 
@@ -101,6 +103,48 @@ class SuppressionTest :
                     collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
                 result.shouldBeEmpty()
+            }
+
+            test("collect only report specific vulnerability ID if one specified") {
+                val vuln =
+                    vulnerability(
+                        id = VulnId.Cve("CVE-2024-0001"),
+                        releases = listOf(releaseV1),
+                        reports = listOf(trivyReport(vulnIds = setOf(VulnId.Cve("CVE-2024-0002")))),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result[ReporterType.TRIVY]!! shouldHaveSize 1
+                result[ReporterType.TRIVY]!![0].id shouldBe VulnId.Cve("CVE-2024-0002")
+            }
+
+            test("collect only report specific vulnerability ID if multiple specified") {
+                val vuln =
+                    vulnerability(
+                        id = VulnId.Cve("CVE-2024-0001"),
+                        releases = listOf(releaseV1),
+                        reports =
+                            listOf(
+                                trivyReport(
+                                    vulnIds =
+                                        setOf(
+                                            VulnId.Cve("CVE-2024-0002"),
+                                            VulnId.Cve("CVE-2024-0003"),
+                                        ),
+                                ),
+                            ),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result[ReporterType.TRIVY]!! shouldHaveSize 2
+                result[ReporterType.TRIVY]!![0].id shouldBe VulnId.Cve("CVE-2024-0002")
+                result[ReporterType.TRIVY]!![1].id shouldBe VulnId.Cve("CVE-2024-0003")
             }
 
             test("filters by single release") {
@@ -233,10 +277,7 @@ class SuppressionTest :
             }
 
             test("filters out non-suppressable reporters") {
-                val entry =
-                    suppressedVuln(
-                        report = ReportEntry(reporter = ReporterType.OTHER, suppress = Suppression()),
-                    )
+                val entry = suppressedVuln(reporter = ReporterType.OTHER)
                 val input = mapOf(ReporterType.OTHER to listOf(entry))
 
                 val result = mapToSuppression(setOf(ReporterType.OTHER), input)
@@ -279,8 +320,7 @@ class SuppressionTest :
 
             test("propagates expiresAt to trivy entries") {
                 val expiresAt = LocalDate.of(2026, 12, 31)
-                val report = trivyReport(suppress = Suppression(expiresAt = expiresAt))
-                val entry = suppressedVuln(report = report)
+                val entry = suppressedVuln(expiresAt = expiresAt)
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
                 val result = mapToSuppression(setOf(ReporterType.TRIVY), input)
@@ -290,8 +330,7 @@ class SuppressionTest :
             }
 
             test("sets expiresAt to null for permanent suppression") {
-                val report = trivyReport(suppress = Suppression(expiresAt = null))
-                val entry = suppressedVuln(report = report)
+                val entry = suppressedVuln(expiresAt = null)
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
                 val result = mapToSuppression(setOf(ReporterType.TRIVY), input)
@@ -300,34 +339,9 @@ class SuppressionTest :
                 trivy.entries.first().expiresAt shouldBe null
             }
 
-            test("uses reporter-specific vulnIds over main id") {
-                val report = trivyReport(vulnIds = setOf(VulnId.Ghsa("GHSA-1234-5678-abcd")))
-                val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report)
-                val input = mapOf(ReporterType.TRIVY to listOf(entry))
-
-                val result = mapToSuppression(setOf(ReporterType.TRIVY), input)
-                val trivy = result.first() as SuppressionOutput.TrivySuppression
-
-                trivy.entries shouldHaveSize 1
-                trivy.entries.first().id shouldBe VulnId.Ghsa("GHSA-1234-5678-abcd")
-            }
-
-            test("falls back to main id when reporter vulnIds are not supported") {
-                val report = trivyReport(vulnIds = setOf(VulnId.Snyk("SNYK-JAVA-001")))
-                val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report)
-                val input = mapOf(ReporterType.TRIVY to listOf(entry))
-
-                val result = mapToSuppression(setOf(ReporterType.TRIVY), input)
-                val trivy = result.first() as SuppressionOutput.TrivySuppression
-
-                trivy.entries shouldHaveSize 1
-                trivy.entries.first().id shouldBe VulnId.Cve("CVE-2024-0001")
-            }
-
             test("deduplicates entries across multiple vulnerabilities") {
-                val report = trivyReport()
-                val entry1 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report)
-                val entry2 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report)
+                val entry1 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"))
+                val entry2 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"))
                 val input = mapOf(ReporterType.TRIVY to listOf(entry1, entry2))
 
                 val result = mapToSuppression(setOf(ReporterType.TRIVY), input)
@@ -340,13 +354,7 @@ class SuppressionTest :
         context("mapToSuppression for Snyk") {
 
             test("maps snyk suppressions to SnykSuppression output") {
-                val report =
-                    ReportEntry(
-                        reporter = ReporterType.SNYK,
-                        vulnIds = setOf(VulnId.Snyk("SNYK-JAVA-001")),
-                        suppress = Suppression(),
-                    )
-                val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report)
+                val entry = suppressedVuln(id = VulnId.Snyk("SNYK-JAVA-001"), reporter = ReporterType.SNYK)
                 val input = mapOf(ReporterType.SNYK to listOf(entry))
 
                 val result = mapToSuppression(setOf(ReporterType.SNYK), input)
@@ -356,14 +364,12 @@ class SuppressionTest :
             }
 
             test("produces correct snyk entries from Snyk vulnId") {
-                val report =
-                    ReportEntry(
-                        reporter = ReporterType.SNYK,
-                        vulnIds = setOf(VulnId.Snyk("SNYK-JAVA-001")),
-                        suppress = Suppression(),
-                    )
                 val entry =
-                    suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report, analysis = "not exploitable")
+                    suppressedVuln(
+                        id = VulnId.Snyk("SNYK-JAVA-001"),
+                        reporter = ReporterType.SNYK,
+                        analysis = "not exploitable",
+                    )
                 val input = mapOf(ReporterType.SNYK to listOf(entry))
 
                 val result = mapToSuppression(setOf(ReporterType.SNYK), input)
@@ -372,6 +378,16 @@ class SuppressionTest :
                 snyk.entries shouldHaveSize 1
                 snyk.entries.first().id shouldBe VulnId.Snyk("SNYK-JAVA-001")
                 snyk.entries.first().reason shouldBe "not exploitable"
+            }
+
+            test("filters out non-snyk vuln ids for Snyk output") {
+                val cveEntry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), reporter = ReporterType.SNYK)
+                val input = mapOf(ReporterType.SNYK to listOf(cveEntry))
+
+                val result = mapToSuppression(setOf(ReporterType.SNYK), input)
+                val snyk = result.first() as SuppressionOutput.SnykSuppression
+
+                snyk.entries.shouldBeEmpty()
             }
 
             test("produces empty SnykSuppression when no suppressions match") {
@@ -384,52 +400,18 @@ class SuppressionTest :
 
             test("propagates expiresAt to snyk entries") {
                 val expiresAt = LocalDate.of(2026, 12, 31)
-                val report =
-                    ReportEntry(
+                val entry =
+                    suppressedVuln(
+                        id = VulnId.Snyk("SNYK-JAVA-001"),
                         reporter = ReporterType.SNYK,
-                        vulnIds = setOf(VulnId.Snyk("SNYK-JAVA-001")),
-                        suppress = Suppression(expiresAt = expiresAt),
+                        expiresAt = expiresAt,
                     )
-                val entry = suppressedVuln(report = report)
                 val input = mapOf(ReporterType.SNYK to listOf(entry))
 
                 val result = mapToSuppression(setOf(ReporterType.SNYK), input)
                 val snyk = result.first() as SuppressionOutput.SnykSuppression
 
                 snyk.entries.first().expiresAt shouldBe expiresAt
-            }
-
-            test("ignores non-snyk vulnIds and falls back to main id if snyk type") {
-                val report =
-                    ReportEntry(
-                        reporter = ReporterType.SNYK,
-                        vulnIds = setOf(VulnId.Cve("CVE-2024-0001")),
-                        suppress = Suppression(),
-                    )
-                val entry = suppressedVuln(id = VulnId.Snyk("SNYK-JAVA-001"), report = report)
-                val input = mapOf(ReporterType.SNYK to listOf(entry))
-
-                val result = mapToSuppression(setOf(ReporterType.SNYK), input)
-                val snyk = result.first() as SuppressionOutput.SnykSuppression
-
-                snyk.entries shouldHaveSize 1
-                snyk.entries.first().id shouldBe VulnId.Snyk("SNYK-JAVA-001")
-            }
-
-            test("produces no entries when neither vulnIds nor main id are snyk type") {
-                val report =
-                    ReportEntry(
-                        reporter = ReporterType.SNYK,
-                        vulnIds = setOf(VulnId.Cve("CVE-2024-0001")),
-                        suppress = Suppression(),
-                    )
-                val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), report = report)
-                val input = mapOf(ReporterType.SNYK to listOf(entry))
-
-                val result = mapToSuppression(setOf(ReporterType.SNYK), input)
-                val snyk = result.first() as SuppressionOutput.SnykSuppression
-
-                snyk.entries.shouldBeEmpty()
             }
         }
 
@@ -458,7 +440,7 @@ class SuppressionTest :
                 result shouldHaveSize 1
             }
 
-            test("not_affected with resolution is excluded") {
+            test("not_affected with resolution is still included") {
                 val vuln =
                     vulnerability(
                         verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
@@ -468,7 +450,7 @@ class SuppressionTest :
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result.shouldBeEmpty()
+                result shouldHaveSize 1
             }
 
             test("affected with resolution is excluded regardless of suppress block") {
@@ -484,7 +466,7 @@ class SuppressionTest :
                 result.shouldBeEmpty()
             }
 
-            test("risk_acceptable with resolution is excluded regardless of suppress block") {
+            test("risk_acceptable with resolution is included when suppress block present") {
                 val vuln =
                     vulnerability(
                         verdict = Verdict.RiskAcceptable(Severity.MEDIUM),
@@ -494,20 +476,7 @@ class SuppressionTest :
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result.shouldBeEmpty()
-            }
-
-            test("not_affected with resolution is excluded regardless of suppress block") {
-                val vuln =
-                    vulnerability(
-                        verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
-                        resolution = Resolution(release = releaseV1),
-                    )
-                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
-
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
-
-                result.shouldBeEmpty()
+                result shouldHaveSize 1
             }
 
             test("affected without resolution is included when suppress block present") {
@@ -538,14 +507,14 @@ class SuppressionTest :
                 result shouldHaveSize 1
             }
 
-            test("risk_acceptable is included when suppress block absent") {
+            test("risk_acceptable is excluded when suppress block absent") {
                 val report = trivyReport(suppress = null)
                 val vuln = vulnerability(reports = listOf(report), verdict = Verdict.RiskAcceptable(Severity.MEDIUM))
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result shouldHaveSize 1
+                result.shouldBeEmpty()
             }
 
             test("under_investigation is included when suppress block present") {
@@ -567,13 +536,23 @@ class SuppressionTest :
                 result.shouldBeEmpty()
             }
 
-            test("risk_acceptable ignores suppress expiration") {
+            test("risk_acceptable respects suppress expiration") {
                 val report = trivyReport(suppress = Suppression(expiresAt = today.minusDays(30)))
                 val vuln =
                     vulnerability(
                         reports = listOf(report),
                         verdict = Verdict.RiskAcceptable(Severity.MEDIUM),
                     )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+
+                result.shouldBeEmpty()
+            }
+
+            test("expires_at equal to today is included") {
+                val report = trivyReport(suppress = Suppression(expiresAt = today))
+                val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
@@ -604,11 +583,17 @@ class SuppressionTest :
                 result.shouldBeEmpty()
             }
 
-            test("excludes vulnerability with resolution even if no date") {
+            test("excludes affected vulnerability with resolution even if no date") {
                 val resolution = Resolution(release = releaseV1, at = null)
                 val file =
                     emptyFile().copy(
-                        vulnerabilities = listOf(vulnerability(resolution = resolution)),
+                        vulnerabilities =
+                            listOf(
+                                vulnerability(
+                                    verdict = Verdict.Affected(Severity.HIGH),
+                                    resolution = resolution,
+                                ),
+                            ),
                     )
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))


### PR DESCRIPTION
Use `vuln_ids` values from the report entry for the target reporter type, if present. Otherwise use the vulnerability's `id` field.

`aliases` are not used for suppression.
