### PR TITLE
feat: Add new copy command to clone vulnerability entries

### DIFF
--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/core/Copy.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/core/Copy.kt
@@ -1,0 +1,75 @@
+package dev.vulnlog.cli.core
+
+import dev.vulnlog.cli.model.Release
+import dev.vulnlog.cli.model.ReleaseEntry
+import dev.vulnlog.cli.parse.v1.dto.VulnerabilityEntryDto
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Finds the latest published release from a list of release entries.
+ *
+ * @param releases The list of release entries to search. Each entry contains a release identifier, publication date,
+ *                 and associated metadata such as package URLs. Releases with a null publication date
+ *                 are considered unpublished.
+ * @return The most recently published release or null if no release has been published.
+ */
+fun latestPublishedRelease(releases: List<ReleaseEntry>): Release? =
+    releases.lastOrNull { it.publicationDate != null }?.id
+
+/**
+ * Serializes a [VulnerabilityEntryDto] object to a YAML-compatible string representation
+ * with specific indentation adjustments for proper formatting.
+ *
+ * The YAML format adjusts the first line with a prefix `-` and indents subsequent lines with spaces.
+ * This ensures that the resulting YAML is appropriately nested for inclusion in larger YAML structures.
+ *
+ * @param entry The [VulnerabilityEntryDto] object to be serialized.
+ * @param mapper An instance of [ObjectMapper] used for converting the entry object into a raw JSON string.
+ * @return A string representing the YAML-compatible serialized format of the given entry.
+ */
+fun serializeEntryYaml(
+    entry: VulnerabilityEntryDto,
+    mapper: ObjectMapper,
+): String {
+    val raw = mapper.writeValueAsString(entry)
+    val lines =
+        raw
+            .lines()
+            .dropWhile { it.trimStart().startsWith("---") || it.isBlank() }
+            .dropLastWhile { it.isBlank() }
+
+    return lines
+        .mapIndexed { index, line ->
+            if (index == 0) "  - $line" else "    $line"
+        }.joinToString("\n")
+}
+
+/**
+ * Inserts a YAML entry immediately after the "vulnerabilities:" header in the given file content.
+ * If the "vulnerabilities:" header is empty (e.g., "vulnerabilities: []"), it converts it to "vulnerabilities:".
+ *
+ * @param fileContent The content of the file as a string, expected to include the "vulnerabilities:" section.
+ * @param entryYaml The YAML entry to be inserted after the "vulnerabilities:" header.
+ * @return The updated file content with the YAML entry inserted after the "vulnerabilities:" header.
+ * @throws IllegalStateException If the "vulnerabilities:" section is not found in the file content.
+ */
+fun insertEntryAfterVulnerabilitiesHeader(
+    fileContent: String,
+    entryYaml: String,
+): String {
+    val lines = fileContent.lines().toMutableList()
+    val headerIndex =
+        lines.indexOfFirst { it.trimEnd() == "vulnerabilities:" || it.trimEnd() == "vulnerabilities: []" }
+    if (headerIndex == -1) {
+        error("No 'vulnerabilities:' section found in target file")
+    }
+
+    if (lines[headerIndex].trimEnd() == "vulnerabilities: []") {
+        lines[headerIndex] = "vulnerabilities:"
+    }
+
+    lines.add(headerIndex + 1, "")
+    lines.add(headerIndex + 2, entryYaml)
+
+    return lines.joinToString("\n")
+}

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/V1Mapper.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/V1Mapper.kt
@@ -29,6 +29,7 @@ import dev.vulnlog.cli.parse.v1.dto.ProjectDto
 import dev.vulnlog.cli.parse.v1.dto.ReleaseEntryDto
 import dev.vulnlog.cli.parse.v1.dto.ReleasePurlEntryDto
 import dev.vulnlog.cli.parse.v1.dto.ReportEntryDto
+import dev.vulnlog.cli.parse.v1.dto.ResolutionDto
 import dev.vulnlog.cli.parse.v1.dto.SuppressionDto
 import dev.vulnlog.cli.parse.v1.dto.TagEntryDto
 import dev.vulnlog.cli.parse.v1.dto.VulnerabilityEntryDto
@@ -55,36 +56,43 @@ object V1Mapper {
         }
 
     private fun vulnerabilitiesToDto(vulnerabilities: List<VulnerabilityEntry>): List<VulnerabilityEntryDto> =
-        vulnerabilities.map {
-            val vulnId =
-                when (it.id) {
-                    is VulnId.Cve -> it.id.id
-                    is VulnId.Ghsa -> it.id.id
-                    is VulnId.RustSec -> it.id.id
-                    is VulnId.Snyk -> it.id.id
+        vulnerabilities.map(::vulnerabilityToDto)
+
+    internal fun vulnerabilityToDto(entry: VulnerabilityEntry): VulnerabilityEntryDto {
+        val vulnId =
+            when (entry.id) {
+                is VulnId.Cve -> entry.id.id
+                is VulnId.Ghsa -> entry.id.id
+                is VulnId.RustSec -> entry.id.id
+                is VulnId.Snyk -> entry.id.id
+            }
+        val aliases =
+            entry.aliases.map { alias ->
+                when (alias) {
+                    is VulnId.Cve -> alias.id
+                    is VulnId.Ghsa -> alias.id
+                    is VulnId.RustSec -> alias.id
+                    is VulnId.Snyk -> alias.id
                 }
-            val aliases =
-                it.aliases.map { alias ->
-                    when (alias) {
-                        is VulnId.Cve -> alias.id
-                        is VulnId.Ghsa -> alias.id
-                        is VulnId.RustSec -> alias.id
-                        is VulnId.Snyk -> alias.id
-                    }
-                }
-            VulnerabilityEntryDto(
-                id = vulnId,
-                aliases = aliases,
-                description = it.description,
-                releases = it.releases.map { release -> release.value },
-                reports = reportsToDto(it.reports),
-                tags = it.tags.map { tag -> tag.value },
-                packages = it.packages.map { purl -> purl.value },
-                analysis = it.analysis,
-                analyzedAt = it.analyzedAt,
-                comment = it.comment,
-            )
-        }
+            }
+        return VulnerabilityEntryDto(
+            id = vulnId,
+            name = entry.name,
+            aliases = aliases,
+            description = entry.description,
+            releases = entry.releases.map { release -> release.value },
+            reports = reportsToDto(entry.reports),
+            tags = entry.tags.map { tag -> tag.value },
+            packages = entry.packages.map { purl -> purl.value },
+            analysis = entry.analysis,
+            analyzedAt = entry.analyzedAt,
+            verdict = verdictToString(entry.verdict),
+            severity = severityToString(entry.verdict),
+            justification = justificationToString(entry.verdict),
+            resolution = entry.resolution?.let { resolutionToDto(it) },
+            comment = entry.comment,
+        )
+    }
 
     private fun reportsToDto(reports: List<ReportEntry>): List<ReportEntryDto> =
         reports.map {
@@ -223,6 +231,43 @@ object V1Mapper {
             "vulnerable_code_not_present" -> VexJustification.VULNERABLE_CODE_NOT_PRESENT
             else -> throw IllegalArgumentException("Invalid justification: $justification")
         }
+
+    private fun verdictToString(verdict: Verdict): String? =
+        when (verdict) {
+            is Verdict.Affected -> "affected"
+            is Verdict.NotAffected -> "not_affected"
+            is Verdict.RiskAcceptable -> "risk_acceptable"
+            is Verdict.UnderInvestigation -> null
+        }
+
+    private fun severityToString(verdict: Verdict): String? =
+        when (verdict) {
+            is Verdict.Affected -> verdict.severity.name.lowercase()
+            is Verdict.RiskAcceptable -> verdict.severity.name.lowercase()
+            else -> null
+        }
+
+    private fun justificationToString(verdict: Verdict): String? =
+        when (verdict) {
+            is Verdict.NotAffected ->
+                when (verdict.justification) {
+                    VexJustification.COMPONENT_NOT_PRESENT -> "component_not_present"
+                    VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST -> "inline_mitigations_already_exists"
+                    VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY ->
+                        "vulnerable_code_cannot_be_controlled_by_adversary"
+                    VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH -> "vulnerable_code_not_in_execute_path"
+                    VexJustification.VULNERABLE_CODE_NOT_PRESENT -> "vulnerable_code_not_present"
+                }
+            else -> null
+        }
+
+    private fun resolutionToDto(resolution: Resolution): ResolutionDto =
+        ResolutionDto(
+            release = resolution.release.value,
+            at = resolution.at,
+            ref = resolution.ref,
+            note = resolution.note,
+        )
 
     private fun vulnerabilityReleasesToDomain(releases: List<String>): List<Release> = releases.map(::Release)
 

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/dto/VulnerabilityEntryDto.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/dto/VulnerabilityEntryDto.kt
@@ -1,24 +1,37 @@
 package dev.vulnlog.cli.parse.v1.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
 data class VulnerabilityEntryDto(
     val id: String,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
+    val name: String? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val aliases: List<String> = emptyList(),
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val description: String? = null,
     val releases: List<String>,
     val packages: List<String>,
     val reports: List<ReportEntryDto>,
+    @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val tags: List<String> = emptyList(),
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val analysis: String? = null,
     @param:JsonProperty("analyzed_at")
     @param:JsonFormat(pattern = "yyyy-MM-dd")
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val analyzedAt: LocalDate? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val verdict: String? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val severity: String? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val justification: String? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val resolution: ResolutionDto? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val comment: String? = null,
 )

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
@@ -1,0 +1,114 @@
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import dev.vulnlog.cli.core.insertEntryAfterVulnerabilitiesHeader
+import dev.vulnlog.cli.core.latestPublishedRelease
+import dev.vulnlog.cli.core.serializeEntryYaml
+import dev.vulnlog.cli.parse.createYamlMapper
+import dev.vulnlog.cli.parse.v1.V1Mapper
+import dev.vulnlog.cli.result.InputValidationResult
+import dev.vulnlog.cli.result.ParseResult
+import dev.vulnlog.cli.shell.shared.parseFile
+import dev.vulnlog.cli.shell.shared.validateFiles
+import dev.vulnlog.cli.shell.shared.validateInputPath
+import java.nio.file.Path
+
+class CopyCommand : CliktCommand(name = "copy") {
+    override val hiddenFromHelp = true
+
+    override fun help(context: Context): String =
+        "Copy vulnerability entries from a source file into one or more target files."
+
+    val source: String by argument(help = "Source Vulnlog file")
+    val targets: List<String> by argument(help = "Target Vulnlog file(s)").multiple()
+
+    val vulnIds: List<String> by option(
+        "--vuln-id",
+        help = "Vulnerability ID to copy (repeatable)",
+    ).multiple(required = true)
+
+    override fun run() {
+        if (targets.isEmpty()) {
+            echo("Error: At least one target file is required.", err = true)
+            throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
+        }
+
+        val sourceResult = parseAndValidateSingle(Path.of(source))
+        val sourceFile = sourceResult.content
+
+        val entries =
+            vulnIds.map { vulnId ->
+                sourceFile.vulnerabilities.find { it.id.id == vulnId }
+                    ?: run {
+                        echo("Error: Vulnerability '$vulnId' not found in source file.", err = true)
+                        throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
+                    }
+            }
+
+        val mapper = createYamlMapper()
+
+        for (targetPathStr in targets) {
+            val targetPath = Path.of(targetPathStr)
+            val targetResult = parseAndValidateSingle(targetPath)
+            val targetFile = targetResult.content
+
+            val existingIds = targetFile.vulnerabilities.map { it.id.id }.toSet()
+
+            val latestRelease = latestPublishedRelease(targetFile.releases)
+            if (latestRelease == null) {
+                echo("Warning: No published release found in ${targetPath.fileName}. Skipping.", err = true)
+                continue
+            }
+
+            var fileContent = targetPath.toFile().readText()
+
+            for (entry in entries) {
+                val entryId = entry.id.id
+                if (entryId in existingIds) {
+                    echo("Warning: '$entryId' already exists in ${targetPath.fileName}. Skipping.", err = true)
+                    continue
+                }
+
+                val dto = V1Mapper.vulnerabilityToDto(entry)
+                val adjustedDto = dto.copy(releases = listOf(latestRelease.value))
+                val entryYaml = serializeEntryYaml(adjustedDto, mapper)
+                fileContent = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
+
+                echo("Copied '$entryId' to ${targetPath.fileName}")
+            }
+
+            targetPath.toFile().writeText(fileContent)
+        }
+    }
+
+    private fun parseAndValidateSingle(path: Path): ParseResult.Ok {
+        val inputResult = validateInputPath(path)
+        if (inputResult is InputValidationResult.Error) {
+            echo(inputResult.message, err = true)
+            throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
+        }
+
+        val parseResults = parseFile(path)
+        parseResults.onEachFailure { file, result ->
+            echo("Parsing of ${file.name} failed:", err = true)
+            echo(result.error, err = true)
+        }
+        if (parseResults.failure.isNotEmpty()) {
+            throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)
+        }
+
+        val validationFindings = validateFiles(parseResults.success)
+        if (validationFindings.renderedFindings.isNotBlank() && validationFindings.hasErrors) {
+            echo(validationFindings.renderedFindings, err = true)
+            throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)
+        }
+
+        return parseResults.success.values.first()
+    }
+}

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
@@ -12,6 +12,7 @@ fun main(args: Array<String>) =
         .subcommands(ValidateCommand())
         .subcommands(SuppressCommand())
         .subcommands(ReportCommand())
+        .subcommands(CopyCommand())
         .main(args)
 
 class VulnlogCli : CliktCommand(name = "vulnlog") {

--- a/next/cli-app/src/test/kotlin/dev/vulnlog/cli/core/CopyTest.kt
+++ b/next/cli-app/src/test/kotlin/dev/vulnlog/cli/core/CopyTest.kt
@@ -1,0 +1,125 @@
+package dev.vulnlog.cli.core
+
+import dev.vulnlog.cli.model.Release
+import dev.vulnlog.cli.model.ReleaseEntry
+import dev.vulnlog.cli.parse.createYamlMapper
+import dev.vulnlog.cli.parse.v1.dto.ReportEntryDto
+import dev.vulnlog.cli.parse.v1.dto.VulnerabilityEntryDto
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.time.LocalDate
+
+class CopyTest :
+    FunSpec({
+
+        test("latestPublishedRelease returns last published release") {
+            val releases =
+                listOf(
+                    ReleaseEntry(id = Release("1.0.0"), publicationDate = LocalDate.of(2025, 1, 1)),
+                    ReleaseEntry(id = Release("1.1.0"), publicationDate = LocalDate.of(2025, 6, 1)),
+                    ReleaseEntry(id = Release("1.2.0")),
+                )
+
+            latestPublishedRelease(releases) shouldBe Release("1.1.0")
+        }
+
+        test("latestPublishedRelease returns null when no releases are published") {
+            val releases =
+                listOf(
+                    ReleaseEntry(id = Release("1.0.0")),
+                    ReleaseEntry(id = Release("1.1.0")),
+                )
+
+            latestPublishedRelease(releases) shouldBe null
+        }
+
+        test("serializeEntryYaml produces correctly indented YAML list item") {
+            val dto =
+                VulnerabilityEntryDto(
+                    id = "CVE-2026-1234",
+                    releases = listOf("1.0.0"),
+                    packages = listOf("pkg:npm/example-lib@2.3.0"),
+                    reports = listOf(ReportEntryDto(reporter = "trivy")),
+                    verdict = "not_affected",
+                    justification = "vulnerable_code_not_in_execute_path",
+                )
+
+            val yaml = serializeEntryYaml(dto, createYamlMapper())
+
+            yaml shouldContain "  - id: "
+            yaml shouldContain "    releases:"
+            yaml shouldContain "    verdict: "
+            yaml shouldNotContain "---"
+        }
+
+        test("serializeEntryYaml omits null fields") {
+            val dto =
+                VulnerabilityEntryDto(
+                    id = "CVE-2026-1234",
+                    releases = listOf("1.0.0"),
+                    packages = listOf("pkg:npm/example-lib@2.3.0"),
+                    reports = listOf(ReportEntryDto(reporter = "trivy")),
+                )
+
+            val yaml = serializeEntryYaml(dto, createYamlMapper())
+
+            yaml shouldNotContain "verdict:"
+            yaml shouldNotContain "severity:"
+            yaml shouldNotContain "justification:"
+            yaml shouldNotContain "analysis:"
+            yaml shouldNotContain "description:"
+            yaml shouldNotContain "comment:"
+            yaml shouldNotContain "resolution:"
+        }
+
+        test("serializeEntryYaml omits empty lists") {
+            val dto =
+                VulnerabilityEntryDto(
+                    id = "CVE-2026-1234",
+                    releases = listOf("1.0.0"),
+                    packages = listOf("pkg:npm/example-lib@2.3.0"),
+                    reports = listOf(ReportEntryDto(reporter = "trivy")),
+                    aliases = emptyList(),
+                    tags = emptyList(),
+                )
+
+            val yaml = serializeEntryYaml(dto, createYamlMapper())
+
+            yaml shouldNotContain "aliases:"
+            yaml shouldNotContain "tags:"
+        }
+
+        test("insertEntryAfterVulnerabilitiesHeader inserts after header") {
+            val fileContent =
+                """
+                |vulnerabilities:
+                |
+                |  - id: "CVE-2026-0001"
+                """.trimMargin()
+
+            val entryYaml = "  - id: \"CVE-2026-9999\"\n    releases:\n      - \"1.0.0\""
+
+            val result = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
+
+            val lines = result.lines()
+            val headerIndex = lines.indexOf("vulnerabilities:")
+            lines[headerIndex + 2] shouldBe "  - id: \"CVE-2026-9999\""
+        }
+
+        test("insertEntryAfterVulnerabilitiesHeader handles empty vulnerabilities list") {
+            val fileContent =
+                """
+                |vulnerabilities: []
+                """.trimMargin()
+
+            val entryYaml = "  - id: \"CVE-2026-9999\"\n    releases:\n      - \"1.0.0\""
+
+            val result = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
+
+            result shouldContain "vulnerabilities:"
+            result shouldNotContain "[]"
+            result shouldContain "CVE-2026-9999"
+        }
+    })

--- a/next/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
+++ b/next/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
@@ -1,0 +1,239 @@
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.testing.test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Files
+
+private val SOURCE_YAML =
+    """
+    # ${'$'}schema: https://vulnlog.dev/schema/vulnlog-v1.json
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 2.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 2.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        analysis: >
+          The vulnerable code path is not reachable.
+        verdict: not_affected
+        justification: vulnerable_code_not_in_execute_path
+
+      - id: CVE-2026-5678
+        releases: [ 2.0.0 ]
+        description: XSS in other-lib
+        packages: [ "pkg:npm/other-lib@1.0.0" ]
+        reports:
+          - reporter: trivy
+        verdict: not_affected
+        justification: component_not_present
+    """.trimIndent()
+
+private val TARGET_YAML =
+    """
+    # ${'$'}schema: https://vulnlog.dev/schema/vulnlog-v1.json
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2025-06-01
+
+    vulnerabilities:
+
+      - id: CVE-2026-0001
+        releases: [ 1.0.0 ]
+        description: Existing entry
+        packages: [ "pkg:npm/foo@1.0.0" ]
+        reports:
+          - reporter: trivy
+        verdict: not_affected
+        justification: component_not_present
+    """.trimIndent()
+
+class CopyCommandTest :
+    FunSpec({
+
+        test("copy single entry to single target") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            val targetFile = Files.createTempFile("target", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+                targetFile.writeText(TARGET_YAML)
+
+                val result =
+                    CopyCommand().test(
+                        "${sourceFile.absolutePath} ${targetFile.absolutePath} --vuln-id CVE-2026-1234",
+                    )
+
+                result.statusCode shouldBe 0
+                result.stdout shouldContain "Copied 'CVE-2026-1234'"
+
+                val targetContent = targetFile.readText()
+                targetContent shouldContain "CVE-2026-1234"
+                targetContent shouldContain "1.0.0"
+                targetContent shouldNotContain "2.0.0"
+            } finally {
+                sourceFile.delete()
+                targetFile.delete()
+            }
+        }
+
+        test("copy single entry to multiple targets") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            val targetFile1 = Files.createTempFile("target1", ".vl.yaml").toFile()
+            val targetFile2 = Files.createTempFile("target2", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+                targetFile1.writeText(TARGET_YAML)
+                targetFile2.writeText(TARGET_YAML)
+
+                val result =
+                    CopyCommand().test(
+                        "${sourceFile.absolutePath} ${targetFile1.absolutePath} ${targetFile2.absolutePath} --vuln-id CVE-2026-1234",
+                    )
+
+                result.statusCode shouldBe 0
+                targetFile1.readText() shouldContain "CVE-2026-1234"
+                targetFile2.readText() shouldContain "CVE-2026-1234"
+            } finally {
+                sourceFile.delete()
+                targetFile1.delete()
+                targetFile2.delete()
+            }
+        }
+
+        test("copy multiple vuln-ids") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            val targetFile = Files.createTempFile("target", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+                targetFile.writeText(TARGET_YAML)
+
+                val result =
+                    CopyCommand().test(
+                        "${sourceFile.absolutePath} ${targetFile.absolutePath} --vuln-id CVE-2026-1234 --vuln-id CVE-2026-5678",
+                    )
+
+                result.statusCode shouldBe 0
+                val targetContent = targetFile.readText()
+                targetContent shouldContain "CVE-2026-1234"
+                targetContent shouldContain "CVE-2026-5678"
+            } finally {
+                sourceFile.delete()
+                targetFile.delete()
+            }
+        }
+
+        test("skip target that already contains the entry") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            val targetFile = Files.createTempFile("target", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+                targetFile.writeText(TARGET_YAML.replace("CVE-2026-0001", "CVE-2026-1234"))
+
+                val result =
+                    CopyCommand().test(
+                        "${sourceFile.absolutePath} ${targetFile.absolutePath} --vuln-id CVE-2026-1234",
+                    )
+
+                result.statusCode shouldBe 0
+                result.stderr shouldContain "already exists"
+            } finally {
+                sourceFile.delete()
+                targetFile.delete()
+            }
+        }
+
+        test("error when vuln-id not found in source") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            val targetFile = Files.createTempFile("target", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+                targetFile.writeText(TARGET_YAML)
+
+                val result =
+                    CopyCommand().test(
+                        "${sourceFile.absolutePath} ${targetFile.absolutePath} --vuln-id CVE-9999-0000",
+                    )
+
+                result.statusCode shouldBe ExitCode.GENERAL_ERROR.ordinal
+                result.stderr shouldContain "not found in source"
+            } finally {
+                sourceFile.delete()
+                targetFile.delete()
+            }
+        }
+
+        test("error when source file does not exist") {
+            val targetFile = Files.createTempFile("target", ".vl.yaml").toFile()
+            try {
+                val result =
+                    CopyCommand().test(
+                        "/nonexistent/source.vl.yaml ${targetFile.absolutePath} --vuln-id CVE-2026-1234",
+                    )
+
+                result.statusCode shouldBe ExitCode.GENERAL_ERROR.ordinal
+                result.stderr shouldContain "does not exist"
+            } finally {
+                targetFile.delete()
+            }
+        }
+
+        test("error when target file does not exist") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+
+                val result =
+                    CopyCommand().test(
+                        "${sourceFile.absolutePath} /nonexistent/target.vl.yaml --vuln-id CVE-2026-1234",
+                    )
+
+                result.statusCode shouldBe ExitCode.GENERAL_ERROR.ordinal
+                result.stderr shouldContain "does not exist"
+            } finally {
+                sourceFile.delete()
+            }
+        }
+
+        test("copy adjusts releases to target latest published release") {
+            val sourceFile = Files.createTempFile("source", ".vl.yaml").toFile()
+            val targetFile = Files.createTempFile("target", ".vl.yaml").toFile()
+            try {
+                sourceFile.writeText(SOURCE_YAML)
+                targetFile.writeText(TARGET_YAML)
+
+                CopyCommand().test(
+                    "${sourceFile.absolutePath} ${targetFile.absolutePath} --vuln-id CVE-2026-1234",
+                )
+
+                val targetContent = targetFile.readText()
+                targetContent shouldContain "\"1.0.0\""
+            } finally {
+                sourceFile.delete()
+                targetFile.delete()
+            }
+        }
+    })


### PR DESCRIPTION
This copies a complete vulnerability entry from a source file into one or more target files.
Use this command to propagate an existing analysis across multiple branch files.

Note that the command is hidden in the CLI for now and requires further testing.