### PR TITLE
fix: Fix native binary copy command and do not copy null or empty lists

### DIFF
--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/dto/ReportEntryDto.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/dto/ReportEntryDto.kt
@@ -1,6 +1,7 @@
 package dev.vulnlog.cli.parse.v1.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
@@ -8,8 +9,11 @@ data class ReportEntryDto(
     val reporter: String,
     @param:JsonFormat(pattern = "yyyy-MM-dd")
     val at: LocalDate? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val source: String? = null,
     @param:JsonProperty("vuln_ids")
+    @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val vulnIds: Set<String> = emptySet(),
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val suppress: SuppressionDto? = null,
 )

--- a/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/dto/ResolutionDto.kt
+++ b/next/cli-app/src/main/kotlin/dev/vulnlog/cli/parse/v1/dto/ResolutionDto.kt
@@ -1,6 +1,7 @@
 package dev.vulnlog.cli.parse.v1.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
@@ -9,6 +10,8 @@ data class ResolutionDto(
     val release: String,
     @param:JsonFormat(pattern = "yyyy-MM-dd")
     val at: LocalDate? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val ref: String? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val note: String? = null,
 )

--- a/next/cli-app/src/main/resources/META-INF/native-image/dev.vulnlog/cli/reflect-config.json
+++ b/next/cli-app/src/main/resources/META-INF/native-image/dev.vulnlog/cli/reflect-config.json
@@ -106,5 +106,23 @@
     "allDeclaredFields": true,
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true
+  },
+  {
+    "name": "kotlin.collections.EmptySet",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "kotlin.collections.EmptyList",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "kotlin.collections.EmptyMap",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
   }
 ]

--- a/next/cli-app/src/test/kotlin/dev/vulnlog/cli/core/CopyTest.kt
+++ b/next/cli-app/src/test/kotlin/dev/vulnlog/cli/core/CopyTest.kt
@@ -72,6 +72,8 @@ class CopyTest :
             yaml shouldNotContain "description:"
             yaml shouldNotContain "comment:"
             yaml shouldNotContain "resolution:"
+            yaml shouldNotContain "source:"
+            yaml shouldNotContain "suppress:"
         }
 
         test("serializeEntryYaml omits empty lists") {
@@ -89,6 +91,7 @@ class CopyTest :
 
             yaml shouldNotContain "aliases:"
             yaml shouldNotContain "tags:"
+            yaml shouldNotContain "vuln_ids:"
         }
 
         test("insertEntryAfterVulnerabilitiesHeader inserts after header") {


### PR DESCRIPTION
- add missing GraalVM reflection configuration
- improve general copying to ignore empty or null values