### PR TITLE
feat: Add Gradle plugin

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -198,3 +198,27 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest
+
+  publish-gradle-plugin:
+    name: Publish Gradle plugin
+    needs: [ generate-changelog ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Publish Gradle plugin
+        env:
+          ORG_GRADLE_PROJECT_gradle.publish.key: ${{ secrets.GRADLE_PLUGIN_KEY }}
+          ORG_GRADLE_PROJECT_gradle.publish.secret: ${{ secrets.GRADLE_PLUGIN_SECRET }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          ./gradlew :gradle-plugin:publishPlugins -PappVersion="$VERSION"

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -21,6 +21,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/modules/cli-app" />
+            <option value="$PROJECT_DIR$/modules/gradle-plugin" />
             <option value="$PROJECT_DIR$/modules/lib" />
           </set>
         </option>

--- a/modules/gradle-plugin/build.gradle.kts
+++ b/modules/gradle-plugin/build.gradle.kts
@@ -1,0 +1,75 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
+
+plugins {
+    id("vulnlog.common-convention")
+    `java-gradle-plugin`
+    id("com.gradle.plugin-publish") version "2.1.1"
+    id("com.gradleup.shadow") version "9.4.1"
+}
+
+description = "Vulnlog Gradle plugin"
+
+group = "dev.vulnlog"
+
+val shaded: Configuration by configurations.creating
+
+configurations {
+    compileOnly.get().extendsFrom(shaded)
+    testImplementation.get().extendsFrom(shaded)
+}
+
+dependencies {
+    shaded(project(":lib"))
+
+    testImplementation(gradleTestKit())
+    testImplementation(libs.kotestAssertionsCoreJvm)
+    testImplementation(libs.kotestRunnerJunit5Jvm)
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    configurations = listOf(shaded)
+    relocate("tools.jackson", "dev.vulnlog.shaded.tools.jackson")
+    relocate("com.github.packageurl", "dev.vulnlog.shaded.com.github.packageurl")
+    mergeServiceFiles()
+}
+
+tasks.named<Jar>("jar") {
+    enabled = false
+    dependsOn(tasks.named("shadowJar"))
+}
+
+tasks.named<PluginUnderTestMetadata>("pluginUnderTestMetadata") {
+    pluginClasspath.from(shaded)
+}
+
+gradlePlugin {
+    website = "https://github.com/vulnlog/vulnlog"
+    vcsUrl = "https://github.com/vulnlog/vulnlog.git"
+    plugins {
+        create("vulnlog") {
+            id = "dev.vulnlog.plugin"
+            displayName = "Vulnlog"
+            description =
+                """
+                Manage vulnerability records as code. Validate Vulnlog YAML files,
+                generate suppression files for downstream scanners (Trivy, Snyk,
+                generic format), and produce self-contained HTML vulnerability reports.
+                """.trimIndent()
+            tags =
+                listOf(
+                    "vulnlog",
+                    "vulnerability",
+                    "security",
+                    "cve",
+                    "audit",
+                    "suppression",
+                    "sca",
+                    "trivy",
+                    "snyk",
+                )
+            implementationClass = "dev.vulnlog.gradle.VulnlogPlugin"
+        }
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogExtension.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogExtension.kt
@@ -1,0 +1,55 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import org.gradle.api.Action
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import javax.inject.Inject
+
+abstract class VulnlogExtension
+    @Inject
+    constructor(
+        objects: ObjectFactory,
+    ) {
+        val files: ConfigurableFileCollection = objects.fileCollection()
+
+        val validate: VulnlogValidateExtension =
+            objects.newInstance(VulnlogValidateExtension::class.java).apply {
+                strict.convention(false)
+            }
+
+        val suppress: VulnlogSuppressExtension =
+            objects.newInstance(VulnlogSuppressExtension::class.java)
+
+        val report: VulnlogReportExtension =
+            objects.newInstance(VulnlogReportExtension::class.java)
+
+        fun validate(action: Action<VulnlogValidateExtension>) = action.execute(validate)
+
+        fun suppress(action: Action<VulnlogSuppressExtension>) = action.execute(suppress)
+
+        fun report(action: Action<VulnlogReportExtension>) = action.execute(report)
+    }
+
+interface VulnlogValidateExtension {
+    val strict: Property<Boolean>
+}
+
+interface VulnlogSuppressExtension {
+    val outputDir: DirectoryProperty
+    val reporter: Property<String>
+    val release: Property<String>
+    val tags: SetProperty<String>
+}
+
+interface VulnlogReportExtension {
+    val outputFile: RegularFileProperty
+    val reporter: Property<String>
+    val release: Property<String>
+    val tags: SetProperty<String>
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogInitTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogInitTask.kt
@@ -1,0 +1,39 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import dev.vulnlog.lib.core.init
+import dev.vulnlog.lib.model.SchemaVersion
+import dev.vulnlog.lib.parse.YamlWriter
+import dev.vulnlog.lib.parse.createYamlMapper
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class VulnlogInitTask : DefaultTask() {
+    @get:Input
+    abstract val organization: Property<String>
+
+    @get:Input
+    abstract val projectName: Property<String>
+
+    @get:Input
+    abstract val author: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val vulnlogFile = init(SchemaVersion(1, 0), organization.get(), projectName.get(), author.get())
+        val content = YamlWriter.write(vulnlogFile, createYamlMapper())
+        val file = outputFile.get().asFile
+        file.writeText(content)
+        logger.lifecycle("Vulnlog file created at: ${file.absolutePath}")
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogPlugin.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogPlugin.kt
@@ -1,0 +1,56 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class VulnlogPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.create("vulnlog", VulnlogExtension::class.java)
+
+        project.tasks.register("vulnlogInit", VulnlogInitTask::class.java) { task ->
+            task.description = "Initiate a new Vulnlog YAML file."
+            task.group = "vulnlog"
+            task.organization.convention(project.propertyOrNull("vulnlog.organization"))
+            task.projectName.convention(project.propertyOrNull("vulnlog.name"))
+            task.author.convention(project.propertyOrNull("vulnlog.author"))
+            task.outputFile.convention(
+                project.propertyOrNull("vulnlog.output")?.let { project.layout.projectDirectory.file(it) },
+            )
+        }
+
+        project.tasks.register("vulnlogValidate", VulnlogValidateTask::class.java) { task ->
+            task.description = "Validate Vulnlog YAML files."
+            task.group = "vulnlog"
+            task.files.from(extension.files)
+            task.strict.convention(extension.validate.strict)
+        }
+
+        project.tasks.register("vulnlogSuppress", VulnlogSuppressTask::class.java) { task ->
+            task.description = "Generate suppression files."
+            task.group = "vulnlog"
+            task.files.from(extension.files)
+            task.reporter.convention(extension.suppress.reporter)
+            task.release.convention(extension.suppress.release)
+            task.tags.convention(extension.suppress.tags)
+            task.outputDir.convention(
+                extension.suppress.outputDir.orElse(project.layout.buildDirectory.dir("vulnlog/suppressions")),
+            )
+        }
+
+        project.tasks.register("vulnlogReport", VulnlogReportTask::class.java) { task ->
+            task.description = "Generate an HTML vulnerability report."
+            task.group = "vulnlog"
+            task.files.from(extension.files)
+            task.reporter.convention(extension.report.reporter)
+            task.release.convention(extension.report.release)
+            task.tags.convention(extension.report.tags)
+            task.outputFile.convention(
+                extension.report.outputFile.orElse(project.layout.buildDirectory.file("vulnlog/vulnlog-report.html")),
+            )
+        }
+    }
+}
+
+private fun Project.propertyOrNull(name: String): String? = providers.gradleProperty(name).orNull

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
@@ -1,0 +1,74 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import dev.vulnlog.gradle.internal.buildFilter
+import dev.vulnlog.gradle.internal.parseAndValidate
+import dev.vulnlog.lib.core.collectReportingEntries
+import dev.vulnlog.lib.core.mergeReportingEntries
+import dev.vulnlog.lib.core.validateSharedProject
+import dev.vulnlog.lib.parse.reporting.HtmlReportMapper
+import dev.vulnlog.lib.parse.reporting.HtmlReportWriter
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.time.LocalDate
+
+@CacheableTask
+abstract class VulnlogReportTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val files: ConfigurableFileCollection
+
+    @get:Input
+    @get:Optional
+    abstract val reporter: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val release: Property<String>
+
+    @get:Input
+    abstract val tags: SetProperty<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val inputFiles = files.files
+        if (inputFiles.isEmpty()) {
+            throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
+        }
+
+        val vulnlogFiles = parseAndValidate(inputFiles)
+
+        val project =
+            validateSharedProject(vulnlogFiles)
+                ?: throw GradleException("All input files must share the same project metadata.")
+
+        val filter = buildFilter(vulnlogFiles.first(), reporter.orNull, release.orNull, tags.get())
+
+        val allEntries = vulnlogFiles.flatMap { collectReportingEntries(it, filter) }
+        val merged = mergeReportingEntries(allEntries)
+
+        val reportData = HtmlReportMapper.toDto(project, merged, LocalDate.now())
+        val reportContent = HtmlReportWriter.renderHtmlReport(reportData)
+
+        val out = outputFile.get().asFile
+        out.parentFile?.mkdirs()
+        out.writeText(reportContent)
+        logger.lifecycle("Report written to: ${out.absolutePath}")
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogSuppressTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogSuppressTask.kt
@@ -1,0 +1,80 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import dev.vulnlog.gradle.internal.buildFilter
+import dev.vulnlog.gradle.internal.parseAndValidate
+import dev.vulnlog.lib.core.SuppressionFilter
+import dev.vulnlog.lib.core.collectSuppressedVulnerabilities
+import dev.vulnlog.lib.core.mapToSuppression
+import dev.vulnlog.lib.parse.suppression.SuppressionWriter
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class VulnlogSuppressTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val files: ConfigurableFileCollection
+
+    @get:Input
+    @get:Optional
+    abstract val reporter: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val release: Property<String>
+
+    @get:Input
+    abstract val tags: SetProperty<String>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val inputFiles = files.files
+        if (inputFiles.isEmpty()) {
+            throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
+        }
+        if (inputFiles.size > 1) {
+            throw GradleException(
+                "vulnlogSuppress supports a single Vulnlog file, but ${inputFiles.size} are configured.",
+            )
+        }
+
+        val vulnlogFile = parseAndValidate(inputFiles).first()
+        val filter = buildFilter(vulnlogFile, reporter.orNull, release.orNull, tags.get())
+
+        val targetReporters =
+            vulnlogFile.vulnerabilities
+                .flatMap { it.reports }
+                .map { it.reporter }
+                .filter { filter.reporter == null || it == filter.reporter }
+                .toSet()
+
+        val suppressionVulns = collectSuppressedVulnerabilities(vulnlogFile, SuppressionFilter(filter))
+        val outputs = mapToSuppression(targetReporters, suppressionVulns)
+
+        val dir = outputDir.get().asFile
+        dir.mkdirs()
+        outputs.forEach { suppressionOutput ->
+            val suppressionFile = SuppressionWriter.writeSuppressionOutput(suppressionOutput)
+            val outputPath = dir.resolve(suppressionFile.fileName)
+            outputPath.writeText(suppressionFile.content)
+            logger.lifecycle("Suppression file created at: ${outputPath.absolutePath}")
+        }
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
@@ -1,0 +1,78 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import dev.vulnlog.lib.core.renderValidation
+import dev.vulnlog.lib.core.validate
+import dev.vulnlog.lib.model.VulnlogFileContext
+import dev.vulnlog.lib.parse.YamlParser
+import dev.vulnlog.lib.parse.createYamlMapper
+import dev.vulnlog.lib.result.ParseResult
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class VulnlogValidateTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val files: ConfigurableFileCollection
+
+    @get:Input
+    abstract val strict: Property<Boolean>
+
+    @TaskAction
+    fun validate() {
+        val inputFiles = files.files
+        if (inputFiles.isEmpty()) {
+            throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
+        }
+
+        val parser = YamlParser(createYamlMapper())
+        val parseResults = inputFiles.associateWith { file -> parser.parse(file.readText()) }
+
+        val errors = parseResults.filter { (_, result) -> result is ParseResult.Error }
+        if (errors.isNotEmpty()) {
+            val messages =
+                errors.map { (file, result) ->
+                    "Parsing of ${file.name} failed:\n${(result as ParseResult.Error).error}"
+                }
+            throw GradleException(messages.joinToString("\n\n"))
+        }
+
+        val successResults = parseResults.mapValues { (_, result) -> result as ParseResult.Ok }
+
+        val contextToResults =
+            successResults.map { (file, parseResult) ->
+                val context = VulnlogFileContext(parseResult.validationVersion, file.name, parseResult.content)
+                context to validate(context)
+            }
+
+        val renderedFindings =
+            contextToResults
+                .filter { (_, result) -> result.findings.isNotEmpty() }
+                .joinToString("\n\n") { (context, result) ->
+                    "Validation findings for ${context.fileName}:\n${renderValidation(result)}"
+                }
+
+        val hasErrors = contextToResults.any { (_, result) -> result.errors.isNotEmpty() }
+        val hasWarnings = contextToResults.any { (_, result) -> result.warnings.isNotEmpty() }
+
+        if (renderedFindings.isNotBlank()) {
+            logger.warn(renderedFindings)
+        }
+
+        if (hasErrors || (hasWarnings && strict.get())) {
+            throw GradleException("Vulnlog validation failed.")
+        } else {
+            logger.lifecycle("Vulnlog validation OK")
+        }
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/Filters.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/Filters.kt
@@ -1,0 +1,67 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle.internal
+
+import dev.vulnlog.lib.core.VulnlogFilter
+import dev.vulnlog.lib.model.Release
+import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.Tag
+import dev.vulnlog.lib.model.VulnlogFile
+import org.gradle.api.GradleException
+
+internal fun buildFilter(
+    vulnlogFile: VulnlogFile,
+    reporter: String?,
+    release: String?,
+    tags: Set<String>,
+): VulnlogFilter =
+    VulnlogFilter(
+        releases = resolveReleases(release, vulnlogFile),
+        tags = resolveTags(tags, vulnlogFile),
+        reporter = resolveReporter(reporter),
+    )
+
+private fun resolveReporter(reporter: String?): ReporterType? =
+    reporter?.let { value ->
+        runCatching { ReporterType.valueOf(value.uppercase()) }
+            .getOrElse {
+                val supported = ReporterType.entries.joinToString(", ") { it.name.lowercase() }
+                throw GradleException("Invalid reporter: $value. Supported: $supported")
+            }
+    }
+
+private fun resolveReleases(
+    releaseOption: String?,
+    vulnlogFile: VulnlogFile,
+): Set<Release> {
+    if (releaseOption == null) return emptySet()
+    val release =
+        runCatching { Release(releaseOption) }
+            .getOrElse { throw GradleException("Invalid release: $releaseOption") }
+    val ordered = vulnlogFile.releases.map { it.id }
+    val index = ordered.indexOf(release)
+    if (index == -1) {
+        val known = ordered.joinToString(", ") { it.value }
+        throw GradleException("Release not found: $releaseOption. Known releases: $known")
+    }
+    return ordered.take(index + 1).toSet()
+}
+
+private fun resolveTags(
+    tagOptions: Set<String>,
+    vulnlogFile: VulnlogFile,
+): Set<Tag> {
+    if (tagOptions.isEmpty()) return emptySet()
+    val tags =
+        runCatching { tagOptions.map(::Tag).toSet() }
+            .getOrElse { throw GradleException("Invalid tag: ${it.message}") }
+    val known = vulnlogFile.tags.map { it.id }.toSet()
+    val unknown = tags.filterNot { it in known }
+    if (unknown.isNotEmpty()) {
+        val knownList = known.joinToString(", ") { it.value }
+        throw GradleException(
+            "Tag not found: ${unknown.joinToString(", ") { it.value }}. Known tags: $knownList",
+        )
+    }
+    return tags
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/ParseAndValidate.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/ParseAndValidate.kt
@@ -1,0 +1,47 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle.internal
+
+import dev.vulnlog.lib.core.renderValidation
+import dev.vulnlog.lib.core.validate
+import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.model.VulnlogFileContext
+import dev.vulnlog.lib.parse.YamlParser
+import dev.vulnlog.lib.parse.createYamlMapper
+import dev.vulnlog.lib.result.ParseResult
+import org.gradle.api.GradleException
+import java.io.File
+
+internal fun parseAndValidate(files: Collection<File>): List<VulnlogFile> {
+    val parser = YamlParser(createYamlMapper())
+    val parseResults = files.associateWith { file -> parser.parse(file.readText()) }
+
+    val errors = parseResults.filter { (_, result) -> result is ParseResult.Error }
+    if (errors.isNotEmpty()) {
+        val messages =
+            errors.map { (file, result) ->
+                "Parsing of ${file.name} failed:\n${(result as ParseResult.Error).error}"
+            }
+        throw GradleException(messages.joinToString("\n\n"))
+    }
+
+    val ok = parseResults.mapValues { (_, result) -> result as ParseResult.Ok }
+
+    val findings =
+        ok.map { (file, result) ->
+            val context = VulnlogFileContext(result.validationVersion, file.name, result.content)
+            context to validate(context)
+        }
+
+    val rendered =
+        findings
+            .filter { (_, r) -> r.errors.isNotEmpty() }
+            .joinToString("\n\n") { (ctx, r) ->
+                "Validation findings for ${ctx.fileName}:\n${renderValidation(r)}"
+            }
+    if (rendered.isNotBlank()) {
+        throw GradleException(rendered)
+    }
+
+    return ok.values.map { it.content }
+}

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogInitTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogInitTaskTest.kt
@@ -1,0 +1,90 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+private val BUILD_FILE =
+    """
+    plugins {
+        id("dev.vulnlog.plugin")
+    }
+    """.trimIndent()
+
+private fun projectDir(): File {
+    val dir = createTempDirectory("vulnlog-init-test").toFile()
+    dir.resolve("build.gradle.kts").writeText(BUILD_FILE)
+    dir.resolve("settings.gradle.kts").writeText("")
+    return dir
+}
+
+private fun runner(
+    projectDir: File,
+    vararg args: String,
+): GradleRunner =
+    GradleRunner
+        .create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments(*args)
+
+class VulnlogInitTaskTest :
+    FunSpec({
+
+        test("creates a vulnlog file with configured values") {
+            val dir = projectDir()
+
+            val result =
+                runner(
+                    dir,
+                    "vulnlogInit",
+                    "-Pvulnlog.organization=Acme Corp",
+                    "-Pvulnlog.name=Widget",
+                    "-Pvulnlog.author=Alice",
+                    "-Pvulnlog.output=vulnlog.yaml",
+                ).build()
+
+            result.task(":vulnlogInit")?.outcome shouldBe TaskOutcome.SUCCESS
+            val content = dir.resolve("vulnlog.yaml").readText()
+            content shouldContain "Acme Corp"
+            content shouldContain "Widget"
+            content shouldContain "Alice"
+            content shouldContain "schemaVersion:"
+        }
+
+        test("fails when required properties are missing") {
+            val dir = projectDir()
+
+            val result =
+                runner(
+                    dir,
+                    "vulnlogInit",
+                    "-Pvulnlog.name=Widget",
+                    "-Pvulnlog.author=Alice",
+                    "-Pvulnlog.output=vulnlog.yaml",
+                ).buildAndFail()
+
+            result.task(":vulnlogInit")?.outcome shouldBe TaskOutcome.FAILED
+        }
+
+        test("fails when output is not specified") {
+            val dir = projectDir()
+
+            val result =
+                runner(
+                    dir,
+                    "vulnlogInit",
+                    "-Pvulnlog.organization=Acme Corp",
+                    "-Pvulnlog.name=Widget",
+                    "-Pvulnlog.author=Alice",
+                ).buildAndFail()
+
+            result.task(":vulnlogInit")?.outcome shouldBe TaskOutcome.FAILED
+        }
+    })

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogReportTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogReportTaskTest.kt
@@ -1,0 +1,211 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+private val VALID_VULNLOG_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+private val OTHER_PROJECT_VULNLOG_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Other Corp
+      name: Other App
+      author: Other Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+      - id: CVE-2026-9999
+        releases: [ 1.0.0 ]
+        description: Other vuln
+        packages: [ "pkg:npm/other-lib@1.0.0" ]
+        reports:
+          - reporter: trivy
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+private fun buildFile(extra: String = "") =
+    """
+    plugins {
+        id("dev.vulnlog.plugin")
+    }
+    $extra
+    """.trimIndent()
+
+private fun projectDir(
+    buildScript: String,
+    vararg yamlFiles: Pair<String, String>,
+): File {
+    val dir = createTempDirectory("vulnlog-report-test").toFile()
+    dir.resolve("build.gradle.kts").writeText(buildScript)
+    dir.resolve("settings.gradle.kts").writeText("")
+    for ((name, content) in yamlFiles) {
+        dir.resolve(name).writeText(content)
+    }
+    return dir
+}
+
+private fun runner(
+    projectDir: File,
+    vararg args: String,
+): GradleRunner =
+    GradleRunner
+        .create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments(*args)
+
+class VulnlogReportTaskTest :
+    FunSpec({
+
+        test("writes report to default output file") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to VALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogReport").build()
+
+            result.task(":vulnlogReport")?.outcome shouldBe TaskOutcome.SUCCESS
+            result.output shouldContain "Report written to:"
+            val report = dir.resolve("build/vulnlog/vulnlog-report.html")
+            report.exists() shouldBe true
+            report.readText() shouldContain "CVE-2026-1234"
+        }
+
+        test("writes report to configured output file") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                            report {
+                                outputFile = layout.projectDirectory.file("custom-report.html")
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to VALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogReport").build()
+
+            result.task(":vulnlogReport")?.outcome shouldBe TaskOutcome.SUCCESS
+            dir.resolve("custom-report.html").exists() shouldBe true
+        }
+
+        test("merges entries from multiple files of the same project") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("a.vl.yaml", "b.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "a.vl.yaml" to VALID_VULNLOG_YAML,
+                    "b.vl.yaml" to VALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogReport").build()
+
+            result.task(":vulnlogReport")?.outcome shouldBe TaskOutcome.SUCCESS
+            dir.resolve("build/vulnlog/vulnlog-report.html").exists() shouldBe true
+        }
+
+        test("fails when input files have different project metadata") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("a.vl.yaml", "b.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "a.vl.yaml" to VALID_VULNLOG_YAML,
+                    "b.vl.yaml" to OTHER_PROJECT_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogReport").buildAndFail()
+
+            result.task(":vulnlogReport")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "must share the same project metadata"
+        }
+
+        test("fails when no files are configured") {
+            val dir = projectDir(buildFile())
+
+            val result = runner(dir, "vulnlogReport").buildAndFail()
+
+            result.task(":vulnlogReport")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "No Vulnlog files configured"
+        }
+
+        test("fails on invalid reporter value") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                            report {
+                                reporter = "bogus"
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to VALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogReport").buildAndFail()
+
+            result.task(":vulnlogReport")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "Invalid reporter: bogus"
+        }
+    })

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogSuppressTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogSuppressTaskTest.kt
@@ -1,0 +1,220 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+private val SUPPRESSABLE_VULNLOG_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        analysis: vulnerable code not in execute path
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+private val MULTI_REPORTER_VULNLOG_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+          - reporter: grype
+        analysis: vulnerable code not in execute path
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+private fun buildFile(extra: String = "") =
+    """
+    plugins {
+        id("dev.vulnlog.plugin")
+    }
+    $extra
+    """.trimIndent()
+
+private fun projectDir(
+    buildScript: String,
+    vararg yamlFiles: Pair<String, String>,
+): File {
+    val dir = createTempDirectory("vulnlog-suppress-test").toFile()
+    dir.resolve("build.gradle.kts").writeText(buildScript)
+    dir.resolve("settings.gradle.kts").writeText("")
+    for ((name, content) in yamlFiles) {
+        dir.resolve(name).writeText(content)
+    }
+    return dir
+}
+
+private fun runner(
+    projectDir: File,
+    vararg args: String,
+): GradleRunner =
+    GradleRunner
+        .create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments(*args)
+
+class VulnlogSuppressTaskTest :
+    FunSpec({
+
+        test("writes suppression file to default output directory") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to SUPPRESSABLE_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogSuppress").build()
+
+            result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.SUCCESS
+            result.output shouldContain "Suppression file created at:"
+            val outputDir = dir.resolve("build/vulnlog/suppressions")
+            (outputDir.list()?.toList() ?: emptyList()) shouldContain ".trivyignore.yaml"
+            outputDir.resolve(".trivyignore.yaml").readText() shouldContain "CVE-2026-1234"
+        }
+
+        test("writes suppression file to configured output directory") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                            suppress {
+                                outputDir = layout.projectDirectory.dir("out")
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to SUPPRESSABLE_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogSuppress").build()
+
+            result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.SUCCESS
+            dir.resolve("out/.trivyignore.yaml").exists() shouldBe true
+        }
+
+        test("filters by reporter") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                            suppress {
+                                reporter = "trivy"
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to MULTI_REPORTER_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogSuppress").build()
+
+            result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.SUCCESS
+            val outputDir = dir.resolve("build/vulnlog/suppressions")
+            val files = outputDir.list()?.toList() ?: emptyList()
+            files shouldContain ".trivyignore.yaml"
+            files.any { it.startsWith("grype") } shouldBe false
+        }
+
+        test("fails when no files are configured") {
+            val dir = projectDir(buildFile())
+
+            val result = runner(dir, "vulnlogSuppress").buildAndFail()
+
+            result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "No Vulnlog files configured"
+        }
+
+        test("fails when multiple files are configured") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("a.vl.yaml", "b.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "a.vl.yaml" to SUPPRESSABLE_VULNLOG_YAML,
+                    "b.vl.yaml" to SUPPRESSABLE_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogSuppress").buildAndFail()
+
+            result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "supports a single Vulnlog file"
+        }
+
+        test("fails on invalid reporter value") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                            suppress {
+                                reporter = "bogus"
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to SUPPRESSABLE_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogSuppress").buildAndFail()
+
+            result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "Invalid reporter: bogus"
+        }
+    })

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogValidateTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogValidateTaskTest.kt
@@ -1,0 +1,216 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+private val VALID_VULNLOG_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+private val INVALID_VULNLOG_YAML =
+    """
+    ---
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+    """.trimIndent()
+
+private val WARNING_VULNLOG_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        analyzed_at: 2025-01-01
+        reports:
+          - reporter: trivy
+            at: 2026-06-01
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+private fun buildFile(extra: String = "") =
+    """
+    plugins {
+        id("dev.vulnlog.plugin")
+    }
+    $extra
+    """.trimIndent()
+
+private fun projectDir(
+    buildScript: String,
+    vararg yamlFiles: Pair<String, String>,
+): File {
+    val dir = createTempDirectory("vulnlog-test").toFile()
+    dir.resolve("build.gradle.kts").writeText(buildScript)
+    dir.resolve("settings.gradle.kts").writeText("")
+    for ((name, content) in yamlFiles) {
+        dir.resolve(name).writeText(content)
+    }
+    return dir
+}
+
+private fun runner(
+    projectDir: File,
+    vararg args: String,
+): GradleRunner =
+    GradleRunner
+        .create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments(*args)
+
+class VulnlogValidateTaskTest :
+    FunSpec({
+
+        test("succeeds on valid vulnlog file") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to VALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogValidate").build()
+
+            result.task(":vulnlogValidate")?.outcome shouldBe TaskOutcome.SUCCESS
+            result.output shouldContain "Vulnlog validation OK"
+        }
+
+        test("fails when no files are configured") {
+            val dir = projectDir(buildFile())
+
+            val result = runner(dir, "vulnlogValidate").buildAndFail()
+
+            result.task(":vulnlogValidate")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "No Vulnlog files configured"
+        }
+
+        test("fails on invalid yaml") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to INVALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogValidate").buildAndFail()
+
+            result.task(":vulnlogValidate")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "Parsing"
+            result.output shouldContain "failed"
+        }
+
+        test("succeeds with warnings when strict is false") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to WARNING_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogValidate").build()
+
+            result.task(":vulnlogValidate")?.outcome shouldBe TaskOutcome.SUCCESS
+            result.output shouldContain "WARN"
+        }
+
+        test("fails with warnings when strict is true") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("test.vl.yaml")
+                            validate {
+                                strict = true
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    "test.vl.yaml" to WARNING_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogValidate").buildAndFail()
+
+            result.task(":vulnlogValidate")?.outcome shouldBe TaskOutcome.FAILED
+            result.output shouldContain "Vulnlog validation failed"
+        }
+
+        test("validates multiple files") {
+            val dir =
+                projectDir(
+                    buildFile(
+                        """
+                        vulnlog {
+                            files.from("a.vl.yaml", "b.vl.yaml")
+                        }
+                        """.trimIndent(),
+                    ),
+                    "a.vl.yaml" to VALID_VULNLOG_YAML,
+                    "b.vl.yaml" to VALID_VULNLOG_YAML,
+                )
+
+            val result = runner(dir, "vulnlogValidate").build()
+
+            result.task(":vulnlogValidate")?.outcome shouldBe TaskOutcome.SUCCESS
+            result.output shouldContain "Vulnlog validation OK"
+        }
+    })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,8 @@ rootProject.name = "vulnlog"
 
 include(":cli-app")
 include(":lib")
+include(":gradle-plugin")
 
 project(":cli-app").projectDir = file("modules/cli-app")
 project(":lib").projectDir = file("modules/lib")
+project(":gradle-plugin").projectDir = file("modules/gradle-plugin")


### PR DESCRIPTION
The Gradle plugin allows to easily use Vulnlog in Gradle based projects. It exposed tasks for these Vulnlog CLI commands:

- init
- validate
- suppress
- report

Use it: `id("dev.vulnlog.plugin") version "<version>"`