### PR TITLE
ci: Improve CI/CD pipelines

### DIFF
--- a/.github/changelog.toml
+++ b/.github/changelog.toml
@@ -111,6 +111,9 @@ commit_parsers = [
 protect_breaking_commits = true
 # Exclude commits that are not matched by any commit parser.
 filter_commits = false
+# Regex to exclude git tags after applying the tag_pattern.
+# Release-candidate tags are excluded so their commits roll up into the eventual final release.
+ignore_tags = "-rc"
 # Order releases topologically instead of chronologically.
 topo_order = false
 # Order of commits in each group/release within the changelog.

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,21 +3,22 @@ name: Continuous Deployment
 on:
   push:
     tags:
-      - "v0.1[0-9].*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+      - "!v0.9.*"
 
 permissions:
-  contents: write
-  discussions: write
-  packages: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   generate-changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
     outputs:
-      release_notes_body: ${{ steps.release-notes.outputs.content }}
+      release_notes_body: ${{ steps.release-notes.outputs.content || steps.release-notes-rc.outputs.content }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,26 +28,38 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: .github/changelog.toml
-          args: --tag ${{ github.ref }} --github-repo ${{ github.repository }}
+          args: --tag ${{ github.ref_name }} --github-repo ${{ github.repository }}
         env:
           OUTPUT: CHANGELOG.md
       - name: Commit CHANGELOG.md
+        if: ${{ !contains(github.ref_name, '-') }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "docs(changelog): update for ${{ github.ref }}" || echo "No changes to commit"
+          git commit -m "docs(changelog): update for ${{ github.ref_name }}" || echo "No changes to commit"
           git pull --rebase origin main
           git push origin HEAD:main
       - name: Generate release notes
+        if: ${{ !contains(github.ref_name, '-') }}
         uses: orhun/git-cliff-action@v4
         id: release-notes
         with:
           config: .github/release-notes.toml
           args: --latest --github-repo ${{ github.repository }}
+      - name: Release notes for RC
+        if: ${{ contains(github.ref_name, '-') }}
+        id: release-notes-rc
+        run: |
+          {
+            echo 'content<<EOF'
+            echo '🚧 Release candidate. Final release notes will be published with the final version.'
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
   build-native-images:
     name: Build native image (${{ matrix.artifact-name }})
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -67,7 +80,7 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Build native image
         shell: bash
         run: |
@@ -84,6 +97,10 @@ jobs:
     name: Publish release
     needs: [ generate-changelog, build-native-images ]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      discussions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,7 +111,7 @@ jobs:
           distribution: 'temurin'
           architecture: x64
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Build JVM distribution
         run: |
           VERSION="${{ github.ref_name }}"
@@ -126,12 +143,13 @@ jobs:
             native-images/*.zip
       - name: Create a new GitHub discussion
         id: create-discussion
-        uses: abirismyname/create-discussion@main
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: abirismyname/create-discussion@c2b7c825241769dda523865ae444a879f6bbd0e0 # v2.1.0
         with:
           title: Vulnlog ${{ github.ref_name }} is released
           body: |
             Vulnlog ${{ github.ref_name }} is released!
-            
+
             For a full description of changes, take a look at our [release notes](https://github.com/vulnlog/vulnlog/releases/tag/${{ github.ref_name }}).
           category-name: Announcements
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +157,12 @@ jobs:
   deploy-pages:
     name: Deploy website and docs to GitHub Pages
     needs: [ publish-release ]
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -174,6 +197,9 @@ jobs:
     name: Publish Docker image
     needs: [ build-native-images ]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -197,12 +223,13 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+            ${{ !contains(github.ref_name, '-') && format('ghcr.io/{0}:latest', github.repository) || '' }}
 
   publish-gradle-plugin:
     name: Publish Gradle plugin
     needs: [ generate-changelog ]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -213,7 +240,7 @@ jobs:
           distribution: 'temurin'
           architecture: x64
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish Gradle plugin
         env:
           ORG_GRADLE_PROJECT_gradle.publish.key: ${{ secrets.GRADLE_PLUGIN_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,19 +5,21 @@ on:
   push:
     branches:
       - main
-      - vl-0.9
-  schedule:
-    - cron: "0 0 * * 0"
   workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pr-validation:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,8 +60,31 @@ jobs:
             chore
             ci
 
+  detect-changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      native_relevant: ${{ steps.filter.outputs.native_relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Detect native-image-relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            native_relevant:
+              - 'modules/lib/src/main/resources/META-INF/native-image/**'
+              - 'modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/**'
+              - 'modules/cli-app/**'
+              - 'modules/lib/build.gradle.kts'
+              - 'gradle/libs.versions.toml'
+              - 'buildSrc/**'
+
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,13 +95,20 @@ jobs:
           distribution: 'temurin'
           architecture: x64
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Check
         run: ./gradlew check
 
   native-image:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    needs: [ detect-changes ]
+    if: |
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'pull_request' && needs.detect-changes.outputs.native_relevant == 'true')
+      )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -87,7 +119,7 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Build native image
         run: ./gradlew :cli-app:nativeCompile --no-configuration-cache
       - name: Upload native image
@@ -100,7 +132,9 @@ jobs:
   publish-docker:
     name: Publish snapshot Docker image
     needs: [ native-image ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       packages: write
     steps:

--- a/devdoc/GitHub-Action-Pipelines.md
+++ b/devdoc/GitHub-Action-Pipelines.md
@@ -1,0 +1,112 @@
+# GitHub Action Pipelines
+
+Three pipelines drive the project:
+
+| Pipeline               | File                                                | Trigger                                                               |
+|------------------------|-----------------------------------------------------|-----------------------------------------------------------------------|
+| Continuous Integration | [`ci.yaml`](../.github/workflows/ci.yaml)           | Pull requests, pushes to `main` and `vl-0.9`, weekly schedule, manual |
+| Continuous Deployment  | [`cd.yaml`](../.github/workflows/cd.yaml)           | Tags matching `vx.y.z` or `vx.y.z-rcN`                                |
+| Security Scanning      | [`security.yml`](../.github/workflows/security.yml) | Weekly schedule, manual                                               |
+
+## CI
+
+Validates pull requests and main-branch pushes.
+
+The `native-image` job is conditional: it always runs on `main` pushes and `workflow_dispatch`, but on pull requests
+only when the diff touches files relevant to the native build (detected via `dorny/paths-filter`).
+
+The `publish-docker` job pushes a `:snapshot` image on every `main` push.
+
+```mermaid
+flowchart TD
+    PR{{Pull request}}
+    PUSH{{Push to main}}
+    DISP{{Manual}}
+    PR --> PRV[pr-validation<br/>DCO + PR title]
+    PR --> DC[detect-changes<br/>paths-filter]
+    PR --> CHK[check<br/>./gradlew check]
+    PUSH --> CHK
+    DISP --> CHK
+    DC --> NI[native-image<br/>Linux GraalVM build]
+    PUSH --> NI
+    DISP --> NI
+    NI --> PD[publish-docker<br/>ghcr.io :snapshot]
+```
+
+### Job details
+
+- **pr-validation**: verifies every commit in the PR has a `Signed-off-by` trailer (DCO) and validates the PR title
+  against the conventional-commits prefixes.
+- **detect-changes**: sets the `native_relevant` output if the PR touches any of:
+  `modules/lib/src/main/resources/META-INF/native-image/**`, `modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/**`,
+  `modules/cli-app/**`, `modules/lib/build.gradle.kts`, `gradle/libs.versions.toml`, `buildSrc/**`.
+- **check**: runs `./gradlew check` (compile, lint, unit tests, JVM integration tests) on Java 21 / Temurin.
+- **native-image**: builds the Linux native binary via `:cli-app:nativeCompile` on GraalVM 25 and uploads it as artifact
+  `vulnlog-linux-amd64`.
+- **publish-docker**: downloads the native binary and pushes `ghcr.io/<repo>:snapshot`. Only runs on `main` pushes.
+
+## CD
+
+Triggered by version tags. Release Candidate tags (e.g. `v0.12.0-rc1`) are detected via the `-` in the tag name; for
+those, the changelog commit, GitHub discussion, the `:latest` Docker tag, and the docs/website deploy are skipped, while
+native binaries, the (pre-)release, the versioned Docker tag, and the Gradle plugin publication still run.
+
+```mermaid
+flowchart TD
+    TAG{{Tag vx.y.z or vx.y.z-rcN}}
+    TAG --> GC[generate-changelog<br/>git-cliff]
+    TAG --> BNI[build-native-images<br/>matrix: linux / macos / windows]
+    GC --> PR2[publish-release<br/>GitHub release + discussion]
+    BNI --> PR2
+    PR2 --> DP[deploy-pages<br/>Antora docs + website]
+    BNI --> PDR[publish-docker<br/>ghcr.io :version + :latest]
+    GC --> PGP[publish-gradle-plugin<br/>plugins.gradle.org]
+```
+
+Steps marked with dashed borders run only on final tags (no `-` in the tag name); other RC-aware gates apply at the step
+level inside their jobs.
+
+### Job details
+
+- **generate-changelog**: runs `git-cliff` twice: once to update `CHANGELOG.md` (committed to `main` only on final tags)
+  and once to produce the release-notes body for the GitHub release.
+- **build-native-images**: matrix build of native binaries for `ubuntu-latest`, `macos-latest`, and `windows-latest`,
+  each on GraalVM 25. The version (`-PappVersion=...`) is taken from the tag with the leading `v` stripped.
+- **publish-release**: builds the JVM distribution zip, downloads and re-zips the three native binaries, and creates a
+  GitHub release marked `prerelease: true`. On final tags also opens an Announcement discussion via
+  `abirismyname/create-discussion` (pinned to v2.1.0 by SHA).
+- **deploy-pages**: builds the Antora documentation, composes the static site, and deploys to GitHub Pages (
+  `vulnlog.dev`). Skipped entirely on RC tags.
+- **publish-docker**: downloads the Linux native binary and pushes `ghcr.io/<repo>:<tag>`; the floating `:latest` tag is
+  added only on final releases.
+- **publish-gradle-plugin**: runs `:gradle-plugin:publishPlugins`. Credentials are passed via
+  `ORG_GRADLE_PROJECT_gradle.publish.key` / `...secret`. The Gradle plugin's `:lib` dependency is shaded into the
+  published jar (see [`modules/gradle-plugin/build.gradle.kts`](../modules/gradle-plugin/build.gradle.kts)) so no
+  separate `:lib` artifact needs publishing.
+
+## Security
+
+Weekly scan that mirrors the way downstream consumers would invoke Vulnlog: a `suppress` step generates ignore files via
+the released Docker image, then Snyk and Trivy run in parallel against the workspace using those files.
+
+```mermaid
+flowchart TD
+    SCH{{Weekly / Manual}}
+    SCH --> SUP[suppress<br/>vulnlog suppress vulnlog.yaml]
+    SUP --> SNYK[snyk<br/>Snyk Open Source]
+    SUP --> TRV[trivy<br/>Trivy filesystem scan]
+    SNYK --> SARIF1[(SARIF -> GitHub Code Scanning)]
+    TRV --> SARIF2[(SARIF -> GitHub Code Scanning)]
+```
+
+### Job details
+
+- **suppress**: runs `ghcr.io/<repo>:latest suppress vulnlog.yaml -o /work` to produce `.snyk` and `.trivyignore.yaml`,
+  then uploads them as the `suppressions` artifact. `continue-on-error: true` so a missing image or empty Vulnlog config
+  does not fail the whole run.
+- **snyk**: runs `snyk/actions/gradle@master` with `--policy-path=.snyk --all-sub-projects`; uploads results as SARIF
+  under category `snyk`. Requires `SNYK_API_KEY` secret.
+- **trivy**: runs `aquasecurity/trivy-action@master` with `scan-type: fs` and `trivyignores: .trivyignore.yaml`; uploads
+  results as SARIF under category `trivy`.
+
+Both scanner jobs require `security-events: write` to upload SARIF.

--- a/devdoc/Releasing.md
+++ b/devdoc/Releasing.md
@@ -15,11 +15,13 @@ The version is `SNAPSHOT+<git-short-hash>`, so it is always traceable to a speci
 
 Releases are automated via the [CD pipeline](../.github/workflows/cd.yaml).
 Tag a commit on `main` with the version (without the `v` prefix in the build, but with it in the tag),
-then push the tag. The pipeline triggers on tags matching `v0.1[0-9].*` (e.g. `v0.10.0`, `v0.11.2`).
+then push the tag. The pipeline triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+`
+(e.g. `v0.10.0`, `v0.11.2`, `v1.0.0`); maintenance tags `v0.9.*` are excluded and handled by
+[`cd-0.9.yaml`](../.github/workflows/cd-0.9.yaml).
 
 ```terminal
-git tag v0.10.0
-git push origin v0.10.0
+git tag v0.12.0
+git push origin v0.12.0
 ```
 
 The pipeline will:
@@ -28,10 +30,48 @@ The pipeline will:
 2. Build native images for Linux, macOS, and Windows in parallel
 3. Build the JVM distribution zip
 4. Create a GitHub release (marked as pre-release) with all four artifacts attached
-5. Post a release announcement in GitHub Discussions
+5. Publish the Gradle plugin to the Gradle Plugin Portal
+6. Push the Docker image to `ghcr.io` with both `:<version>` and `:latest` tags
+7. Deploy the website and Antora docs to GitHub Pages
+8. Post a release announcement in GitHub Discussions
 
 Once you are satisfied with the release notes, publish the release manually from the GitHub UI
 to remove the pre-release flag.
+
+## Release candidates
+
+To validate the final binaries before cutting a release, tag a release candidate first.
+RC tags match `v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+` (e.g. `v0.12.0-rc1`).
+
+```terminal
+git tag v0.12.0-rc1
+git push origin v0.12.0-rc1
+```
+
+The CD pipeline detects RC tags via the `-` in the tag name and skips the steps that should
+only run for a final release:
+
+| Step                            | Final tag | RC tag    |
+|---------------------------------|-----------|-----------|
+| Native images (Linux/macOS/Win) | ✓         | ✓         |
+| GitHub release (pre-release)    | ✓         | ✓         |
+| Docker image `:<version>` tag   | ✓         | ✓         |
+| Gradle plugin publication       | ✓         | ✓         |
+| `CHANGELOG.md` commit to `main` | ✓         | *skipped* |
+| Docker image `:latest` tag      | ✓         | *skipped* |
+| Website and docs deploy         | ✓         | *skipped* |
+| GitHub Discussions announcement | ✓         | *skipped* |
+
+When the manual tests against the RC artifacts pass, tag the *same commit* with the final version
+and push it — the pipeline runs again and performs the steps that were skipped for the RC:
+
+```terminal
+git tag v0.12.0
+git push origin v0.12.0
+```
+
+If an RC reveals a problem, fix it on `main`, then push a fresh RC tag (`v0.12.0-rc2`, …).
+RC tags can be safely deleted from the remote once the final tag is published.
 
 ## Documentation and Antora versioning
 


### PR DESCRIPTION
- Update tag matching
- Allow to create release candidate (rc1, rc2) releases without publishing the website/documentation
- Rework permissions: Only jobs that needs to write have these permissions
- Update setup-gradle action version
- Add timeouts
- Add GitHub action pipeline documentation