### PR TITLE
chore: Bump several GitHub actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -88,7 +88,7 @@ jobs:
           VERSION="${VERSION#v}"
           ./gradlew :cli-app:nativeCompile --no-configuration-cache -PappVersion="$VERSION"
       - name: Upload native image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: modules/cli-app/build/native/nativeCompile/vulnlog${{ runner.os == 'Windows' && '.exe' || '' }}
@@ -118,7 +118,7 @@ jobs:
           VERSION="${VERSION#v}"
           ./gradlew clean :cli-app:distZip -PappVersion="$VERSION"
       - name: Download native images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: vulnlog-*
           path: native-images
@@ -186,12 +186,12 @@ jobs:
           cp schema/*.json _site/schema/
           echo 'vulnlog.dev' > _site/CNAME
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   publish-docker:
     name: Publish Docker image
@@ -204,7 +204,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Download Linux native image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vulnlog-linux-amd64
           path: modules/cli-app/build/native/nativeCompile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Build native image
         run: ./gradlew :cli-app:nativeCompile --no-configuration-cache
       - name: Upload native image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vulnlog-linux-amd64
           path: modules/cli-app/build/native/nativeCompile/vulnlog
@@ -141,7 +141,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Download Linux native image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vulnlog-linux-amd64
           path: modules/cli-app/build/native/nativeCompile

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,9 +35,9 @@ jobs:
           cp schema/*.json _site/schema/
           echo 'vulnlog.dev' > _site/CNAME
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,7 @@ jobs:
           [ -f .trivyignore.yaml ] || touch .trivyignore.yaml
 
       - name: Upload suppression files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: suppressions
           include-hidden-files: true
@@ -48,7 +48,7 @@ jobs:
             report vulnlog.yaml
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: reports
           path: vulnlog-report.html
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download suppression files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: suppressions
 
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download suppression files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: suppressions
 


### PR DESCRIPTION
- upload-artifact to version 7
- download-artifact to version 8
- upload-pages-artifact to version 5
- deploy-pages to version 5