### PR TITLE
fix: Add relocation for Jackson annotation in Gradle plugin

### DIFF
--- a/modules/gradle-plugin/build.gradle.kts
+++ b/modules/gradle-plugin/build.gradle.kts
@@ -31,6 +31,7 @@ tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
     configurations = listOf(shaded)
     relocate("tools.jackson", "dev.vulnlog.shaded.tools.jackson")
+    relocate("com.fasterxml.jackson.annotation", "dev.vulnlog.shaded.com.fasterxml.jackson.annotation")
     relocate("com.github.packageurl", "dev.vulnlog.shaded.com.github.packageurl")
     mergeServiceFiles()
 }


### PR DESCRIPTION
This fixes a Gradle Jackson shadding/relocate bug (JsonFormat POJO) with newer Gradle versions. Older Gradle releases such as 9.1.0 work fine.