### PR TITLE
feat: Introduce the dismissed state in reports

### DIFF
--- a/docs/modules/ROOT/pages/vulnerability-states.adoc
+++ b/docs/modules/ROOT/pages/vulnerability-states.adoc
@@ -1,26 +1,44 @@
 = Vulnerability States
 
 Every vulnerability entry has a state that reflects where it sits in the triage lifecycle.
-State is not written into the YAML directly -- it is derived from which fields are present on the entry each time a report is generated.
+State is not written into the YAML directly -- it is derived from the entry's `verdict` and `resolution` fields each time a report is generated.
 
-== The three states
+== The states
 
 [cols="1,2,3"]
 |===
 | State | Derivation | Meaning
 
 | `under investigation`
-| `analysis` not yet recorded
-| The finding has been registered but triage has not started.
+| no `verdict`
+| The finding has been registered but triage has not concluded.
 
 | `open`
-| `analysis` recorded, no `resolution`
-| Triage is complete and a verdict has been reached. The entry awaits closure.
+| `verdict` is `affected`, no `resolution`
+| Triage is complete and the vulnerability impacts the project. The entry awaits a fix.
 
 | `resolved`
 | `resolution` recorded
-| The maintainer's triage work on the entry is complete.
+| A resolution has been recorded for the entry. The maintainer's triage work is complete.
+
+| `dismissed`
+| `verdict` is `not affected` or `risk acceptable`, no `resolution`
+| Triage concluded that no remediation will be applied. Either the project is not affected, or the risk was assessed and accepted.
 |===
+
+=== Derivation precedence
+
+The rules are evaluated in this order:
+
+. If no `verdict` is recorded, state is `under investigation`.
+. Otherwise, if a `resolution` is recorded, state is `resolved` (regardless of verdict).
+. Otherwise, state is derived from the `verdict`: `affected` yields `open`; `not affected` and `risk acceptable` yield `dismissed`.
+
+=== Terminal states
+
+`resolved` and `dismissed` are both terminal.
+The distinction is intentional: `resolved` means a resolution was recorded (a fix, or a hygiene update on a `not affected` entry), `dismissed` means the entry was closed without any resolution because none was warranted.
+A `not affected` entry that later records a hygiene update moves from `dismissed` to `resolved` and appears in the `Fixed In` column.
 
 == Perspective
 
@@ -35,16 +53,14 @@ Release-scoped questions are answered by other means:
 
 == Typical progression
 
-State derivation depends only on the `analysis` and `resolution` fields.
-The verdict is independent of state and is retained as the entry moves through the lifecycle.
-
-. **New entry.** No `analysis`, no `verdict`.
+. **New entry.** No `verdict`.
 State is `under investigation`.
-. **Triage complete.** `analysis` recorded and `verdict` set.
-State is `open`.
-All xref:verdicts-and-justifications.adoc[verdict values] are valid at this stage.
+. **Triage complete.** `verdict` set.
+** Verdict `affected`: state is `open`, awaiting a fix.
+** Verdict `not affected`: state is `dismissed`. No further action is required.
+** Verdict `risk acceptable`: state is `dismissed`. The risk is accepted without remediation.
 . **Closure.** `resolution` recorded.
-State is `resolved`.
+State is `resolved` regardless of verdict.
 The verdict is retained.
 
 == State in the HTML report
@@ -57,13 +73,13 @@ Entries in every state appear in the same table so the maintainer can see the co
 | Column | Content
 
 | `State`
-| `under investigation`, `open`, or `resolved`.
+| `under investigation`, `open`, `resolved`, or `dismissed`.
 
 | `Releases`
 | Releases in which the vulnerability was reported.
 
 | `Fixed In`
-| Release in which the resolution was applied. Empty for entries that are not `resolved`.
+| Release in which the `resolution` was recorded. Empty for entries that are not `resolved`.
 |===
 
 See xref:cli-report.adoc[`vulnlog report`] for command usage and filters.

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
@@ -9,7 +9,6 @@ import dev.vulnlog.lib.model.VulnlogFile
 import dev.vulnlog.lib.model.report.Impact
 import dev.vulnlog.lib.model.report.ReportingEntry
 import dev.vulnlog.lib.model.report.WorkState
-import kotlin.sequences.map
 
 /**
  * Validates that all provided Vulnlog files share the same project metadata.
@@ -84,12 +83,11 @@ private fun mergeTwo(
     )
 
 private fun findWorkState(vulnEntry: VulnerabilityEntry): WorkState =
-    if (vulnEntry.resolution != null) {
-        WorkState.RESOLVED
-    } else if (vulnEntry.analysis == null) {
-        WorkState.UNDER_INVESTIGATION
-    } else {
-        WorkState.OPEN
+    when (vulnEntry.verdict) {
+        Verdict.UnderInvestigation -> WorkState.UNDER_INVESTIGATION
+        is Verdict.Affected -> if (vulnEntry.resolution != null) WorkState.RESOLVED else WorkState.OPEN
+        is Verdict.NotAffected -> if (vulnEntry.resolution != null) WorkState.RESOLVED else WorkState.DISMISSED
+        is Verdict.RiskAcceptable -> if (vulnEntry.resolution != null) WorkState.RESOLVED else WorkState.DISMISSED
     }
 
 private fun defineImpact(vulnEntry: VulnerabilityEntry): Impact =

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/report/WorkState.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/report/WorkState.kt
@@ -6,4 +6,5 @@ enum class WorkState {
     UNDER_INVESTIGATION,
     OPEN,
     RESOLVED,
+    DISMISSED,
 }

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
@@ -130,6 +130,99 @@ class ReportingTest :
                 result shouldHaveSize 1
                 result.first().primaryId shouldBe cve1
             }
+
+            test("derives under investigation state from UnderInvestigation verdict") {
+                val vuln = vulnerability(verdict = Verdict.UnderInvestigation, analysis = null)
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.UNDER_INVESTIGATION
+            }
+
+            test("derives open state from Affected verdict without resolution") {
+                val vuln = vulnerability(verdict = Verdict.Affected(Severity.HIGH))
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.OPEN
+            }
+
+            test("derives dismissed state from NotAffected verdict without resolution") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.DISMISSED
+            }
+
+            test("derives dismissed state from RiskAcceptable verdict without resolution") {
+                val vuln = vulnerability(verdict = Verdict.RiskAcceptable(Severity.LOW))
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.DISMISSED
+            }
+
+            test("resolution overrides Affected verdict to resolved state") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.RESOLVED
+            }
+
+            test("NotAffected with resolution moves from dismissed to resolved and populates fixedIn") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.RESOLVED
+                result.first().fixedIn shouldBe setOf(releaseV2)
+            }
+
+            test("UnderInvestigation verdict takes precedence over resolution") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.UnderInvestigation,
+                        analysis = null,
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.UNDER_INVESTIGATION
+            }
+
+            test("resolution overrides RiskAcceptable verdict to resolved state") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.RiskAcceptable(Severity.LOW),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file)
+
+                result.first().state shouldBe WorkState.RESOLVED
+            }
         }
 
         context("mergeReportingEntries") {


### PR DESCRIPTION
Vulnerability entries that are either "not affected" or "risk acceptable" are dismissed instead of staying open. This makes it clearer whether there is still work to be done on vulnerability reports.