### PR TITLE
feat: Add copy command and Gradle task

### DIFF
--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
@@ -13,14 +13,14 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.unique
+import dev.vulnlog.lib.core.copyVulnerabilities
 import dev.vulnlog.lib.core.findNonExistingVulnIds
-import dev.vulnlog.lib.core.insertEntryAfterVulnerabilitiesHeader
-import dev.vulnlog.lib.core.latestPublishedRelease
+import dev.vulnlog.lib.core.formatCopiedMessage
+import dev.vulnlog.lib.core.formatSkippedExistingMessage
+import dev.vulnlog.lib.core.formatVulnIdsNotInSourceMessage
 import dev.vulnlog.lib.core.parseVulnId
-import dev.vulnlog.lib.core.serializeEntryYaml
 import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.parse.createYamlMapper
-import dev.vulnlog.lib.parse.v1.V1Mapper
 import dev.vulnlog.lib.shell.FileInputOption
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
@@ -49,55 +49,35 @@ class CopyCommand : CliktCommand(name = "copy") {
         .unique()
 
     override fun run() {
-        val parsedSuccessfully = parseInputOrFail(listOf(source))
-        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
+        val parsedSource = parseInputOrFail(listOf(source))
+        validateParsedInputOrFailWithFailureOutput(parsedSource)
+        val sourceVulnlogFile = parsedSource.values.first().content
 
-        val sourceVulnlogFile = parsedSuccessfully.values.first().content
-        val vulnIdsNotInSourceContent = findNonExistingVulnIds(sourceVulnlogFile.vulnerabilities, vulnIds)
-        if (vulnIdsNotInSourceContent.isNotEmpty()) {
-            echo(
-                "Error: Vulnerability IDs not found in source file: ${vulnIdsNotInSourceContent.joinToString(", ")}",
-                err = true,
-            )
+        val missing = findNonExistingVulnIds(sourceVulnlogFile.vulnerabilities, vulnIds)
+        if (missing.isNotEmpty()) {
+            echo(formatVulnIdsNotInSourceMessage(missing), err = true)
             throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
         }
 
         val mapper = createYamlMapper()
-
         for (destination in destinations) {
-            val parsedTargetSuccessfully = parseInputOrFail(listOf(destination))
-            validateParsedInputOrFailWithFailureOutput(parsedTargetSuccessfully)
+            val parsedDestination = parseInputOrFail(listOf(destination))
+            validateParsedInputOrFailWithFailureOutput(parsedDestination)
+            val destinationVulnlogFile = parsedDestination.values.first().content
 
-            val destinationVulnlogFile = parsedTargetSuccessfully.values.first().content
-            val vulnIdsNotInTargetContent = findNonExistingVulnIds(destinationVulnlogFile.vulnerabilities, vulnIds)
-            val vulnIdsToIgnore = vulnIds.minus(vulnIdsNotInTargetContent)
-            if (vulnIdsToIgnore.isNotEmpty()) {
-                echo(
-                    "Warning: Skipping IDs already exist in ${destination.path}: ${
-                        vulnIdsToIgnore.joinToString(
-                            ", ",
-                        ) { it.id }
-                    }",
-                    err = true,
+            val outcome =
+                copyVulnerabilities(
+                    source = sourceVulnlogFile,
+                    destination = destinationVulnlogFile,
+                    destinationContent = destination.path.readText(),
+                    vulnIds = vulnIds,
+                    mapper = mapper,
                 )
+            if (outcome.skippedAlreadyExisting.isNotEmpty()) {
+                echo(formatSkippedExistingMessage(destination.path, outcome.skippedAlreadyExisting), err = true)
             }
-            val latestRelease = latestPublishedRelease(destinationVulnlogFile.releases)
-
-            val vulnEntries =
-                sourceVulnlogFile.vulnerabilities
-                    .filter { it.id in vulnIdsNotInTargetContent }
-                    // to maintain order when inserting entries as the first one in insertEntryAfterVulnerabilitiesHeader
-                    .reversed()
-
-            var destinationContent = destination.path.readText()
-            for (entry in vulnEntries) {
-                val dto = V1Mapper.vulnerabilityToDto(entry)
-                val adjustedDto = dto.copy(releases = listOf(latestRelease.value))
-                val entryYaml = serializeEntryYaml(adjustedDto, mapper)
-                destinationContent = insertEntryAfterVulnerabilitiesHeader(destinationContent, entryYaml)
-            }
-            destination.path.writeText(destinationContent)
-            echo("Copied to ${destination.path}: ${vulnIdsNotInTargetContent.joinToString(", ") { it.id }}")
+            destination.path.writeText(outcome.newContent)
+            echo(formatCopiedMessage(destination.path, outcome.copied))
         }
     }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
@@ -9,81 +9,95 @@ import com.github.ajalt.clikt.parameters.arguments.ArgumentTransformContext
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.unique
+import dev.vulnlog.lib.core.findNonExistingVulnIds
 import dev.vulnlog.lib.core.insertEntryAfterVulnerabilitiesHeader
 import dev.vulnlog.lib.core.latestPublishedRelease
+import dev.vulnlog.lib.core.parseVulnId
 import dev.vulnlog.lib.core.serializeEntryYaml
+import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.parse.createYamlMapper
 import dev.vulnlog.lib.parse.v1.V1Mapper
 import dev.vulnlog.lib.shell.FileInputOption
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
 
+// TODO move copy after modify command: vulnlog modify copy ...
 class CopyCommand : CliktCommand(name = "copy") {
-    override val hiddenFromHelp = true
-
     override fun help(context: Context): String =
-        "Copy vulnerability entries from a source file into one or more target files."
+        """
+        |Copy vulnerability entries from a source file into one or more target files.
+        |The copied entry's release is set to the latest published release.
+        """.trimMargin()
 
     val source: FileInputOption.File by argument(help = "Source Vulnlog file to copy vulnerabilities from.")
         .convert(conversion = ArgumentTransformContext::toInputFile)
 
-    val targets: List<FileInputOption.File> by argument(help = "Target Vulnlog file(s) to past vulnerabilities into.")
-        .convert(conversion = ArgumentTransformContext::toInputFile)
+    val destinations: List<FileInputOption.File> by argument(
+        help = "Target Vulnlog file(s) to past vulnerabilities into.",
+    ).convert(conversion = ArgumentTransformContext::toInputFile)
         .multiple(required = true)
 
-    val vulnIds: List<String> by option(
+    val vulnIds: Set<VulnId> by option(
         "--vuln-id",
         help = "Vulnerability ID to copy (repeatable)",
-    ).multiple(required = true)
+    ).convert { parseVulnId(it) }
+        .multiple(required = true)
+        .unique()
 
     override fun run() {
         val parsedSuccessfully = parseInputOrFail(listOf(source))
         validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
 
-        val sourceFile = parsedSuccessfully.values.first().content
-        val entries =
-            vulnIds.map { vulnId ->
-                sourceFile.vulnerabilities.find { it.id.id == vulnId }
-                    ?: run {
-                        echo("Error: Vulnerability '$vulnId' not found in source file.", err = true)
-                        throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
-                    }
-            }
+        val sourceVulnlogFile = parsedSuccessfully.values.first().content
+        val vulnIdsNotInSourceContent = findNonExistingVulnIds(sourceVulnlogFile.vulnerabilities, vulnIds)
+        if (vulnIdsNotInSourceContent.isNotEmpty()) {
+            echo(
+                "Error: Vulnerability IDs not found in source file: ${vulnIdsNotInSourceContent.joinToString(", ")}",
+                err = true,
+            )
+            throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
+        }
 
         val mapper = createYamlMapper()
 
-        for (targetPathStr in targets) {
-            val parsedTargetSuccessfully = parseInputOrFail(listOf(targetPathStr))
+        for (destination in destinations) {
+            val parsedTargetSuccessfully = parseInputOrFail(listOf(destination))
             validateParsedInputOrFailWithFailureOutput(parsedTargetSuccessfully)
 
-            val content = parsedTargetSuccessfully.values.first().content
-            val existingIds = content.vulnerabilities.map { it.id.id }.toSet()
-
-            val latestRelease = latestPublishedRelease(content.releases)
-            val targetPath = targetPathStr.path
-            if (latestRelease == null) {
-                echo("Warning: No published release found in ${targetPath.fileName}. Skipping.", err = true)
-                continue
+            val destinationVulnlogFile = parsedTargetSuccessfully.values.first().content
+            val vulnIdsNotInTargetContent = findNonExistingVulnIds(destinationVulnlogFile.vulnerabilities, vulnIds)
+            val vulnIdsToIgnore = vulnIds.minus(vulnIdsNotInTargetContent)
+            if (vulnIdsToIgnore.isNotEmpty()) {
+                echo(
+                    "Warning: Skipping IDs already exist in ${destination.path}: ${
+                        vulnIdsToIgnore.joinToString(
+                            ", ",
+                        ) { it.id }
+                    }",
+                    err = true,
+                )
             }
+            val latestRelease = latestPublishedRelease(destinationVulnlogFile.releases)
 
-            var fileContent = targetPath.toFile().readText()
+            val vulnEntries =
+                sourceVulnlogFile.vulnerabilities
+                    .filter { it.id in vulnIdsNotInTargetContent }
+                    // to maintain order when inserting entries as the first one in insertEntryAfterVulnerabilitiesHeader
+                    .reversed()
 
-            for (entry in entries) {
-                val entryId = entry.id.id
-                if (entryId in existingIds) {
-                    echo("Warning: '$entryId' already exists in ${targetPath.fileName}. Skipping.", err = true)
-                    continue
-                }
-
+            var destinationContent = destination.path.readText()
+            for (entry in vulnEntries) {
                 val dto = V1Mapper.vulnerabilityToDto(entry)
                 val adjustedDto = dto.copy(releases = listOf(latestRelease.value))
                 val entryYaml = serializeEntryYaml(adjustedDto, mapper)
-                fileContent = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
-
-                echo("Copied '$entryId' to ${targetPath.fileName}")
+                destinationContent = insertEntryAfterVulnerabilitiesHeader(destinationContent, entryYaml)
             }
-
-            targetPath.toFile().writeText(fileContent)
+            destination.path.writeText(destinationContent)
+            echo("Copied to ${destination.path}: ${vulnIdsNotInTargetContent.joinToString(", ") { it.id }}")
         }
     }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
@@ -16,7 +16,6 @@ import com.github.ajalt.clikt.parameters.options.unique
 import dev.vulnlog.lib.core.copyVulnerabilities
 import dev.vulnlog.lib.core.findNonExistingVulnIds
 import dev.vulnlog.lib.core.formatCopiedMessage
-import dev.vulnlog.lib.core.formatSkippedExistingMessage
 import dev.vulnlog.lib.core.formatVulnIdsNotInSourceMessage
 import dev.vulnlog.lib.core.parseVulnId
 import dev.vulnlog.lib.model.VulnId
@@ -25,7 +24,6 @@ import dev.vulnlog.lib.shell.FileInputOption
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
-// TODO move copy after modify command: vulnlog modify copy ...
 class CopyCommand : CliktCommand(name = "copy") {
     override fun help(context: Context): String =
         """
@@ -73,9 +71,6 @@ class CopyCommand : CliktCommand(name = "copy") {
                     vulnIds = vulnIds,
                     mapper = mapper,
                 )
-            if (outcome.skippedAlreadyExisting.isNotEmpty()) {
-                echo(formatSkippedExistingMessage(destination.path, outcome.skippedAlreadyExisting), err = true)
-            }
             destination.path.writeText(outcome.newContent)
             echo(formatCopiedMessage(destination.path, outcome.copied))
         }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
@@ -14,7 +14,7 @@ fun main(args: Array<String>) =
         .subcommands(ValidateCommand())
         .subcommands(SuppressCommand())
         .subcommands(ReportCommand())
-        .subcommands(CopyCommand())
+        .subcommands(ModifyCommand())
         .main(args)
 
 class VulnlogCli : CliktCommand(name = "vulnlog") {

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ModifyCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ModifyCommand.kt
@@ -1,0 +1,17 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.subcommands
+
+class ModifyCommand : CliktCommand(name = "modify") {
+    override fun help(context: Context): String = "Modify Vulnlog files (e.g. copy entries between files)."
+
+    init {
+        subcommands(CopyCommand())
+    }
+
+    override fun run() = Unit
+}

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
@@ -119,7 +119,7 @@ class CopyCommandTest :
                 }
             }
 
-            test("skips a target that already contains the entry") {
+            test("merges into a target that already contains the entry") {
                 withTempFile(prefix = "source", content = SOURCE_YAML) { source ->
                     val targetWithEntry = TARGET_YAML.replace("CVE-2026-0001", "CVE-2026-1234")
                     withTempFile(prefix = "target", content = targetWithEntry) { target ->
@@ -129,7 +129,13 @@ class CopyCommandTest :
                             )
 
                         result.statusCode shouldBe 0
-                        result.stderr shouldBe "Warning: Skipping IDs already exist in ${target.path}: CVE-2026-1234\n"
+                        val content = target.readText()
+                        // Existing entry's release was rewritten to the destination's latest release
+                        content shouldContain "\"1.0.0\""
+                        content shouldNotContain "2.0.0"
+                        // Only one CVE-2026-1234 entry remains (no duplicate prepended)
+                        val occurrences = "CVE-2026-1234".toRegex().findAll(content).count()
+                        occurrences shouldBe 1
                     }
                 }
             }

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
@@ -62,7 +62,7 @@ class CopyCommandTest :
                             )
 
                         result.statusCode shouldBe 0
-                        result.stdout shouldContain "Copied 'CVE-2026-1234'"
+                        result.stdout shouldBe "Copied to ${target.path}: CVE-2026-1234\n"
 
                         val content = target.readText()
                         content shouldContain "CVE-2026-1234"
@@ -129,7 +129,7 @@ class CopyCommandTest :
                             )
 
                         result.statusCode shouldBe 0
-                        result.stderr shouldContain "already exists"
+                        result.stderr shouldBe "Warning: Skipping IDs already exist in ${target.path}: CVE-2026-1234\n"
                     }
                 }
             }

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/ModifyCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/ModifyCommandTest.kt
@@ -1,0 +1,30 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.testing.test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+private val SOURCE_YAML = vulnlogYaml(releaseId = "2.0.0", cveId = "CVE-2026-1234")
+private val TARGET_YAML = vulnlogYaml(releaseId = "1.0.0", cveId = "CVE-2026-0001")
+
+class ModifyCommandTest :
+    FunSpec({
+
+        test("'modify copy' invokes the copy subcommand") {
+            withTempFile(prefix = "source", content = SOURCE_YAML) { source ->
+                withTempFile(prefix = "target", content = TARGET_YAML) { target ->
+                    val result =
+                        ModifyCommand().test(
+                            "copy ${source.absolutePath} ${target.absolutePath} --vuln-id CVE-2026-1234",
+                        )
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldContain "Copied to ${target.path}: CVE-2026-1234"
+                    target.readText() shouldContain "CVE-2026-1234"
+                }
+            }
+        }
+    })

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
@@ -4,21 +4,22 @@ package dev.vulnlog.gradle
 
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
+import dev.vulnlog.lib.core.copyVulnerabilities
 import dev.vulnlog.lib.core.findNonExistingVulnIds
-import dev.vulnlog.lib.core.insertEntryAfterVulnerabilitiesHeader
-import dev.vulnlog.lib.core.latestPublishedRelease
+import dev.vulnlog.lib.core.formatCopiedMessage
+import dev.vulnlog.lib.core.formatSkippedExistingMessage
+import dev.vulnlog.lib.core.formatVulnIdsNotInSourceMessage
 import dev.vulnlog.lib.core.parseVulnId
-import dev.vulnlog.lib.core.serializeEntryYaml
 import dev.vulnlog.lib.parse.createYamlMapper
-import dev.vulnlog.lib.parse.v1.V1Mapper
 import dev.vulnlog.lib.shell.FileInputOption
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -26,12 +27,12 @@ import org.gradle.api.tasks.TaskAction
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
-@CacheableTask
 abstract class VulnlogCopyTask : DefaultTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val sourceFiles: ConfigurableFileCollection
+    abstract val sourceFile: RegularFileProperty
 
+    @get:InputFiles
     @get:OutputFiles
     abstract val destinationFiles: ConfigurableFileCollection
 
@@ -40,66 +41,37 @@ abstract class VulnlogCopyTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
-        val inputFiles = sourceFiles.files.map { FileInputOption.File(it.toPath()) }
-        if (inputFiles.isEmpty()) {
-            throw GradleException("No Vulnlog files specified.")
-        }
-        if (inputFiles.size > 1) {
-            throw GradleException("Copy task supports only a single Vulnlog file.")
-        }
+        val sourceInput = FileInputOption.File(sourceFile.get().asFile.toPath())
+        val parsedSource = parseInputOrFail(listOf(sourceInput))
+        validateParsedInputOrFailWithFailureOutput(parsedSource)
+        val sourceVulnlogFile = parsedSource.values.first().content
 
-        val parsedSuccessfully = parseInputOrFail(inputFiles)
-        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
-
-        val sourceVulnlogFile = parsedSuccessfully.values.first().content
-        val vulnIds = vulnIds.get().map { parseVulnId(it) }.toSet()
-        val vulnIdsNotInSourceContent = findNonExistingVulnIds(sourceVulnlogFile.vulnerabilities, vulnIds)
-        if (vulnIdsNotInSourceContent.isNotEmpty()) {
-            throw GradleException(
-                "Error: Vulnerability IDs not found in source file: ${
-                    vulnIdsNotInSourceContent.joinToString(
-                        ", ",
-                    )
-                }",
-            )
+        val vulnIdSet = vulnIds.get().map { parseVulnId(it) }.toSet()
+        val missing = findNonExistingVulnIds(sourceVulnlogFile.vulnerabilities, vulnIdSet)
+        if (missing.isNotEmpty()) {
+            throw GradleException(formatVulnIdsNotInSourceMessage(missing))
         }
 
         val mapper = createYamlMapper()
-
         val destinations = destinationFiles.files.map { FileInputOption.File(it.toPath()) }
         for (destination in destinations) {
-            val parsedTargetSuccessfully = parseInputOrFail(listOf(destination))
-            validateParsedInputOrFailWithFailureOutput(parsedTargetSuccessfully)
+            val parsedDestination = parseInputOrFail(listOf(destination))
+            validateParsedInputOrFailWithFailureOutput(parsedDestination)
+            val destinationVulnlogFile = parsedDestination.values.first().content
 
-            val destinationVulnlogFile = parsedTargetSuccessfully.values.first().content
-            val vulnIdsNotInTargetContent = findNonExistingVulnIds(destinationVulnlogFile.vulnerabilities, vulnIds)
-            val vulnIdsToIgnore = vulnIds.minus(vulnIdsNotInTargetContent)
-            if (vulnIdsToIgnore.isNotEmpty()) {
-                logger.warn(
-                    "Warning: Skipping IDs already exist in ${destination.path}: ${
-                        vulnIdsToIgnore.joinToString(
-                            ", ",
-                        )
-                    }",
+            val outcome =
+                copyVulnerabilities(
+                    source = sourceVulnlogFile,
+                    destination = destinationVulnlogFile,
+                    destinationContent = destination.path.readText(),
+                    vulnIds = vulnIdSet,
+                    mapper = mapper,
                 )
+            if (outcome.skippedAlreadyExisting.isNotEmpty()) {
+                logger.warn(formatSkippedExistingMessage(destination.path, outcome.skippedAlreadyExisting))
             }
-            val latestRelease = latestPublishedRelease(destinationVulnlogFile.releases)
-
-            val vulnEntries =
-                sourceVulnlogFile.vulnerabilities
-                    .filter { it.id in vulnIdsNotInTargetContent }
-                    // to maintain order when inserting entries as the first one in insertEntryAfterVulnerabilitiesHeader
-                    .reversed()
-
-            var destinationContent = destination.path.readText()
-            for (entry in vulnEntries) {
-                val dto = V1Mapper.vulnerabilityToDto(entry)
-                val adjustedDto = dto.copy(releases = listOf(latestRelease.value))
-                val entryYaml = serializeEntryYaml(adjustedDto, mapper)
-                destinationContent = insertEntryAfterVulnerabilitiesHeader(destinationContent, entryYaml)
-            }
-            destination.path.writeText(destinationContent)
-            logger.lifecycle("Copied to ${destination.path}: ${vulnIdsNotInTargetContent.joinToString(", ") { it.id }}")
+            destination.path.writeText(outcome.newContent)
+            logger.lifecycle(formatCopiedMessage(destination.path, outcome.copied))
         }
     }
 }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
@@ -7,7 +7,6 @@ import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
 import dev.vulnlog.lib.core.copyVulnerabilities
 import dev.vulnlog.lib.core.findNonExistingVulnIds
 import dev.vulnlog.lib.core.formatCopiedMessage
-import dev.vulnlog.lib.core.formatSkippedExistingMessage
 import dev.vulnlog.lib.core.formatVulnIdsNotInSourceMessage
 import dev.vulnlog.lib.core.parseVulnId
 import dev.vulnlog.lib.parse.createYamlMapper
@@ -20,20 +19,21 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
+@DisableCachingByDefault
 abstract class VulnlogCopyTask : DefaultTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val sourceFile: RegularFileProperty
 
     @get:InputFiles
-    @get:OutputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val destinationFiles: ConfigurableFileCollection
 
     @get:Input
@@ -67,9 +67,6 @@ abstract class VulnlogCopyTask : DefaultTask() {
                     vulnIds = vulnIdSet,
                     mapper = mapper,
                 )
-            if (outcome.skippedAlreadyExisting.isNotEmpty()) {
-                logger.warn(formatSkippedExistingMessage(destination.path, outcome.skippedAlreadyExisting))
-            }
             destination.path.writeText(outcome.newContent)
             logger.lifecycle(formatCopiedMessage(destination.path, outcome.copied))
         }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
@@ -1,0 +1,105 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.gradle
+
+import dev.vulnlog.gradle.internal.parseInputOrFail
+import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
+import dev.vulnlog.lib.core.findNonExistingVulnIds
+import dev.vulnlog.lib.core.insertEntryAfterVulnerabilitiesHeader
+import dev.vulnlog.lib.core.latestPublishedRelease
+import dev.vulnlog.lib.core.parseVulnId
+import dev.vulnlog.lib.core.serializeEntryYaml
+import dev.vulnlog.lib.parse.createYamlMapper
+import dev.vulnlog.lib.parse.v1.V1Mapper
+import dev.vulnlog.lib.shell.FileInputOption
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+@CacheableTask
+abstract class VulnlogCopyTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceFiles: ConfigurableFileCollection
+
+    @get:OutputFiles
+    abstract val destinationFiles: ConfigurableFileCollection
+
+    @get:Input
+    abstract val vulnIds: SetProperty<String>
+
+    @TaskAction
+    fun generate() {
+        val inputFiles = sourceFiles.files.map { FileInputOption.File(it.toPath()) }
+        if (inputFiles.isEmpty()) {
+            throw GradleException("No Vulnlog files specified.")
+        }
+        if (inputFiles.size > 1) {
+            throw GradleException("Copy task supports only a single Vulnlog file.")
+        }
+
+        val parsedSuccessfully = parseInputOrFail(inputFiles)
+        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
+
+        val sourceVulnlogFile = parsedSuccessfully.values.first().content
+        val vulnIds = vulnIds.get().map { parseVulnId(it) }.toSet()
+        val vulnIdsNotInSourceContent = findNonExistingVulnIds(sourceVulnlogFile.vulnerabilities, vulnIds)
+        if (vulnIdsNotInSourceContent.isNotEmpty()) {
+            throw GradleException(
+                "Error: Vulnerability IDs not found in source file: ${
+                    vulnIdsNotInSourceContent.joinToString(
+                        ", ",
+                    )
+                }",
+            )
+        }
+
+        val mapper = createYamlMapper()
+
+        val destinations = destinationFiles.files.map { FileInputOption.File(it.toPath()) }
+        for (destination in destinations) {
+            val parsedTargetSuccessfully = parseInputOrFail(listOf(destination))
+            validateParsedInputOrFailWithFailureOutput(parsedTargetSuccessfully)
+
+            val destinationVulnlogFile = parsedTargetSuccessfully.values.first().content
+            val vulnIdsNotInTargetContent = findNonExistingVulnIds(destinationVulnlogFile.vulnerabilities, vulnIds)
+            val vulnIdsToIgnore = vulnIds.minus(vulnIdsNotInTargetContent)
+            if (vulnIdsToIgnore.isNotEmpty()) {
+                logger.warn(
+                    "Warning: Skipping IDs already exist in ${destination.path}: ${
+                        vulnIdsToIgnore.joinToString(
+                            ", ",
+                        )
+                    }",
+                )
+            }
+            val latestRelease = latestPublishedRelease(destinationVulnlogFile.releases)
+
+            val vulnEntries =
+                sourceVulnlogFile.vulnerabilities
+                    .filter { it.id in vulnIdsNotInTargetContent }
+                    // to maintain order when inserting entries as the first one in insertEntryAfterVulnerabilitiesHeader
+                    .reversed()
+
+            var destinationContent = destination.path.readText()
+            for (entry in vulnEntries) {
+                val dto = V1Mapper.vulnerabilityToDto(entry)
+                val adjustedDto = dto.copy(releases = listOf(latestRelease.value))
+                val entryYaml = serializeEntryYaml(adjustedDto, mapper)
+                destinationContent = insertEntryAfterVulnerabilitiesHeader(destinationContent, entryYaml)
+            }
+            destination.path.writeText(destinationContent)
+            logger.lifecycle("Copied to ${destination.path}: ${vulnIdsNotInTargetContent.joinToString(", ") { it.id }}")
+        }
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
@@ -4,6 +4,7 @@ package dev.vulnlog.gradle
 
 import dev.vulnlog.gradle.internal.buildFilterOrFail
 import dev.vulnlog.gradle.internal.parseInputOrFail
+import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
 import dev.vulnlog.lib.core.collectReportingEntries
 import dev.vulnlog.lib.core.mergeReportingEntries
@@ -51,9 +52,7 @@ abstract class VulnlogReportTask : DefaultTask() {
     @TaskAction
     fun generate() {
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
-        if (inputFiles.isEmpty()) {
-            throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
-        }
+        requireNonEmptyVulnlogFiles(inputFiles)
         val parsedSuccessfully = parseInputOrFail(inputFiles)
         validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
 

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogSuppressTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogSuppressTask.kt
@@ -4,6 +4,7 @@ package dev.vulnlog.gradle
 
 import dev.vulnlog.gradle.internal.buildFilterOrFail
 import dev.vulnlog.gradle.internal.parseInputOrFail
+import dev.vulnlog.gradle.internal.requireSingleVulnlogFile
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
 import dev.vulnlog.lib.core.SuppressionFilter
 import dev.vulnlog.lib.core.collectSuppressedVulnerabilities
@@ -11,7 +12,6 @@ import dev.vulnlog.lib.core.mapToSuppression
 import dev.vulnlog.lib.parse.suppression.SuppressionWriter
 import dev.vulnlog.lib.shell.FileInputOption
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
@@ -48,14 +48,7 @@ abstract class VulnlogSuppressTask : DefaultTask() {
     @TaskAction
     fun generate() {
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
-        if (inputFiles.isEmpty()) {
-            throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
-        }
-        if (inputFiles.size > 1) {
-            throw GradleException(
-                "vulnlogSuppress supports a single Vulnlog file, but ${inputFiles.size} are configured.",
-            )
-        }
+        requireSingleVulnlogFile("vulnlogSuppress", inputFiles)
         val parsedSuccessfully = parseInputOrFail(inputFiles)
         validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
 

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
@@ -3,6 +3,7 @@
 package dev.vulnlog.gradle
 
 import dev.vulnlog.gradle.internal.parseInputOrFail
+import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
 import dev.vulnlog.lib.shell.FileInputOption
 import org.gradle.api.DefaultTask
@@ -28,9 +29,7 @@ abstract class VulnlogValidateTask : DefaultTask() {
     @TaskAction
     fun validate() {
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
-        if (inputFiles.isEmpty()) {
-            throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
-        }
+        requireNonEmptyVulnlogFiles(inputFiles)
         val parsedSuccessfully = parseInputOrFail(inputFiles)
         val validationFindings = validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
         if (validationFindings.hasWarnings && strict.get()) {

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleWrapper.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleWrapper.kt
@@ -17,6 +17,23 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import java.io.File
 
+fun requireNonEmptyVulnlogFiles(inputFiles: List<FileInputOption.File>) {
+    if (inputFiles.isEmpty()) {
+        throw GradleException("No Vulnlog files configured. Set vulnlog.files in your build script.")
+    }
+}
+
+fun requireSingleVulnlogFile(
+    taskName: String,
+    inputFiles: List<FileInputOption.File>,
+): FileInputOption.File {
+    requireNonEmptyVulnlogFiles(inputFiles)
+    if (inputFiles.size > 1) {
+        throw GradleException("$taskName supports a single Vulnlog file, but ${inputFiles.size} are configured.")
+    }
+    return inputFiles.single()
+}
+
 fun parseInputOrFail(inputFiles: List<FileInputOption.File>): Map<File, ParseResult.Ok> {
     val parseResults: ParseResults =
         try {

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
@@ -4,6 +4,8 @@ package dev.vulnlog.lib.core
 
 import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReleaseEntry
+import dev.vulnlog.lib.model.ReportEntry
+import dev.vulnlog.lib.model.ReporterType
 import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.model.VulnlogFile
@@ -15,14 +17,14 @@ import java.nio.file.Path
 
 data class CopyOutcome(
     val copied: List<VulnId>,
-    val skippedAlreadyExisting: Set<VulnId>,
     val newContent: String,
 )
 
 /**
- * Copies the requested vulnerability entries from [source] into [destinationContent], skipping IDs that
- * already exist in [destination]. The release of each copied entry is rewritten to the destination's
- * latest release (favoring published).
+ * Copies the requested vulnerability entries from [source] into [destinationContent].
+ * If an entry already exists in [destination], it is merged with the source entry: existing values win for
+ * scalars; lists (aliases, packages, tags) are unioned; reports are unioned by reporter. Releases on every
+ * copied entry are rewritten to the destination's latest release (favoring published).
  */
 fun copyVulnerabilities(
     source: VulnlogFile,
@@ -31,30 +33,77 @@ fun copyVulnerabilities(
     vulnIds: Set<VulnId>,
     mapper: ObjectMapper = createYamlMapper(),
 ): CopyOutcome {
-    val toCopy = findNonExistingVulnIds(destination.vulnerabilities, vulnIds)
-    val skipped = vulnIds - toCopy
     val release = lastReleaseFavoringPublished(destination.releases)
-    // insertEntryAfterVulnerabilitiesHeader prepends; reverse so first source entry ends up first
-    val entriesReversed = source.vulnerabilities.filter { it.id in toCopy }.reversed()
+    val sourceEntries = source.vulnerabilities.filter { it.id in vulnIds }
+    val existingById = destination.vulnerabilities.associateBy { it.id }
+
     val newContent =
-        entriesReversed.fold(destinationContent) { acc, entry ->
-            val dto = V1Mapper.vulnerabilityToDto(entry).copy(releases = listOf(release.value))
-            insertEntryAfterVulnerabilitiesHeader(acc, serializeEntryYaml(dto, mapper))
+        sourceEntries.fold(destinationContent) { acc, incoming ->
+            val existing = existingById[incoming.id]
+            val merged = mergeVulnerabilityEntry(existing, incoming, release)
+            val entryYaml = serializeEntryYaml(V1Mapper.vulnerabilityToDto(merged), mapper)
+            if (existing == null) {
+                insertEntryAfterVulnerabilitiesHeader(acc, entryYaml)
+            } else {
+                replaceEntryById(acc, incoming.id, entryYaml)
+            }
         }
     return CopyOutcome(
-        copied = entriesReversed.asReversed().map { it.id },
-        skippedAlreadyExisting = skipped,
+        copied = sourceEntries.map { it.id },
         newContent = newContent,
     )
 }
 
+private fun mergeVulnerabilityEntry(
+    existing: VulnerabilityEntry?,
+    incoming: VulnerabilityEntry,
+    release: Release,
+): VulnerabilityEntry {
+    if (existing == null) return incoming.copy(releases = listOf(release))
+    return existing.copy(
+        name = existing.name ?: incoming.name,
+        aliases = unionPreservingOrder(existing.aliases, incoming.aliases),
+        releases = listOf(release),
+        description = existing.description ?: incoming.description,
+        packages = unionPreservingOrder(existing.packages, incoming.packages),
+        reports = mergeReports(existing.reports, incoming.reports),
+        tags = unionPreservingOrder(existing.tags, incoming.tags),
+        analysis = existing.analysis ?: incoming.analysis,
+        analyzedAt = existing.analyzedAt ?: incoming.analyzedAt,
+        resolution = existing.resolution ?: incoming.resolution,
+        comment = existing.comment ?: incoming.comment,
+    )
+}
+
+private fun <T> unionPreservingOrder(
+    first: List<T>,
+    second: List<T>,
+): List<T> {
+    val seen = first.toMutableSet()
+    return first + second.filter { seen.add(it) }
+}
+
+private fun mergeReports(
+    existing: List<ReportEntry>,
+    incoming: List<ReportEntry>,
+): List<ReportEntry> {
+    val byReporter = LinkedHashMap<ReporterType, ReportEntry>()
+    existing.forEach { byReporter[it.reporter] = it }
+    incoming.forEach { incomingReport ->
+        byReporter.merge(incomingReport.reporter, incomingReport) { e, n ->
+            e.copy(
+                at = e.at ?: n.at,
+                source = e.source ?: n.source,
+                vulnIds = e.vulnIds + n.vulnIds,
+                suppress = e.suppress ?: n.suppress,
+            )
+        }
+    }
+    return byReporter.values.toList()
+}
+
 fun formatVulnIdsNotInSourceMessage(missing: Set<VulnId>): String =
     "Error: Vulnerability IDs not found in source file: ${missing.joinToString(", ") { it.id }}"
-
-fun formatSkippedExistingMessage(
-    destinationPath: Path,
-    ids: Set<VulnId>,
-): String = "Warning: Skipping IDs already exist in $destinationPath: ${ids.joinToString(", ") { it.id }}"
 
 fun formatCopiedMessage(
     destinationPath: Path,
@@ -146,4 +195,48 @@ fun insertEntryAfterVulnerabilitiesHeader(
     lines.add(headerIndex + 2, entryYaml)
 
     return lines.joinToString("\n")
+}
+
+private val ENTRY_ID_LINE = Regex("""^  - id:\s+["']?(\S+?)["']?\s*$""")
+
+/**
+ * Replaces the YAML block of the entry whose `id` matches [vulnId] with [newEntryYaml].
+ * If no such entry is found, falls back to inserting [newEntryYaml] after the `vulnerabilities:` header.
+ *
+ * The block is delimited by the next `  - id:` line, the next top-level YAML key, or the end of the file.
+ * Trailing blank lines that visually separate this entry from the next are preserved as-is.
+ */
+fun replaceEntryById(
+    fileContent: String,
+    vulnId: VulnId,
+    newEntryYaml: String,
+): String {
+    val lines = fileContent.lines()
+    val startIndex =
+        lines.indexOfFirst { line ->
+            ENTRY_ID_LINE.matchEntire(line)?.groupValues?.get(1) == vulnId.id
+        }
+    if (startIndex == -1) {
+        return insertEntryAfterVulnerabilitiesHeader(fileContent, newEntryYaml)
+    }
+    var endIndex = lines.size
+    for (i in startIndex + 1 until lines.size) {
+        val line = lines[i]
+        if (ENTRY_ID_LINE.matches(line)) {
+            endIndex = i
+            break
+        }
+        // top-level YAML key (non-indented, non-blank, non-comment) ends the vulnerabilities section
+        if (line.isNotBlank() && !line.startsWith(" ") && !line.startsWith("#")) {
+            endIndex = i
+            break
+        }
+    }
+    // Walk back over blank separator lines so they remain between this entry and the next
+    while (endIndex > startIndex + 1 && lines[endIndex - 1].isBlank()) {
+        endIndex--
+    }
+
+    val rebuilt = lines.subList(0, startIndex) + newEntryYaml.lines() + lines.subList(endIndex, lines.size)
+    return rebuilt.joinToString("\n")
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
@@ -4,19 +4,34 @@ package dev.vulnlog.lib.core
 
 import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReleaseEntry
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.parse.v1.dto.VulnerabilityEntryDto
 import tools.jackson.databind.ObjectMapper
 
 /**
+ * Identifies vulnerability IDs from a given list that do not exist in the list of known vulnerabilities.
+ *
+ * @param vulnerabilities A list of known vulnerability entries, where each entry includes metadata and a unique ID.
+ * @param vulnIds A list of vulnerability ID strings to be checked against the known vulnerabilities.
+ * @return A set of parsed `VulnId` objects that are not present in the provided list of known vulnerabilities.
+ */
+fun findNonExistingVulnIds(
+    vulnerabilities: List<VulnerabilityEntry>,
+    vulnIds: Set<VulnId>,
+): Set<VulnId> =
+    vulnIds
+        .filter { vulnId -> vulnId !in vulnerabilities.map(VulnerabilityEntry::id) }
+        .toSet()
+
+/**
  * Finds the latest published release from a list of release entries.
  *
- * @param releases The list of release entries to search. Each entry contains a release identifier, publication date,
- *                 and associated metadata such as package URLs. Releases with a null publication date
- *                 are considered unpublished.
- * @return The most recently published release or null if no release has been published.
+ * @param releases The list of release entries to search. Releases with a null publication date are considered unpublished.
+ * @return The most recently published release or the last entry if no release has been published.
  */
-fun latestPublishedRelease(releases: List<ReleaseEntry>): Release? =
-    releases.lastOrNull { it.publicationDate != null }?.id
+fun latestPublishedRelease(releases: List<ReleaseEntry>): Release =
+    releases.lastOrNull { it.publicationDate != null }?.id ?: releases.last().id
 
 /**
  * Serializes a [VulnerabilityEntryDto] object to a YAML-compatible string representation

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
@@ -6,8 +6,65 @@ import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReleaseEntry
 import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.model.VulnerabilityEntry
+import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.parse.createYamlMapper
+import dev.vulnlog.lib.parse.v1.V1Mapper
 import dev.vulnlog.lib.parse.v1.dto.VulnerabilityEntryDto
 import tools.jackson.databind.ObjectMapper
+import java.nio.file.Path
+
+data class CopyOutcome(
+    val copied: List<VulnId>,
+    val skippedAlreadyExisting: Set<VulnId>,
+    val newContent: String,
+)
+
+/**
+ * Copies the requested vulnerability entries from [source] into [destinationContent], skipping IDs that
+ * already exist in [destination]. The release of each copied entry is rewritten to the destination's
+ * latest release (favoring published).
+ */
+fun copyVulnerabilities(
+    source: VulnlogFile,
+    destination: VulnlogFile,
+    destinationContent: String,
+    vulnIds: Set<VulnId>,
+    mapper: ObjectMapper = createYamlMapper(),
+): CopyOutcome {
+    val toCopy = findNonExistingVulnIds(destination.vulnerabilities, vulnIds)
+    val skipped = vulnIds - toCopy
+    val release = lastReleaseFavoringPublished(destination.releases)
+    // insertEntryAfterVulnerabilitiesHeader prepends; reverse so first source entry ends up first
+    val entriesReversed = source.vulnerabilities.filter { it.id in toCopy }.reversed()
+    val newContent =
+        entriesReversed.fold(destinationContent) { acc, entry ->
+            val dto = V1Mapper.vulnerabilityToDto(entry).copy(releases = listOf(release.value))
+            insertEntryAfterVulnerabilitiesHeader(acc, serializeEntryYaml(dto, mapper))
+        }
+    return CopyOutcome(
+        copied = entriesReversed.asReversed().map { it.id },
+        skippedAlreadyExisting = skipped,
+        newContent = newContent,
+    )
+}
+
+fun formatVulnIdsNotInSourceMessage(missing: Set<VulnId>): String =
+    "Error: Vulnerability IDs not found in source file: ${missing.joinToString(", ") { it.id }}"
+
+fun formatSkippedExistingMessage(
+    destinationPath: Path,
+    ids: Set<VulnId>,
+): String = "Warning: Skipping IDs already exist in $destinationPath: ${ids.joinToString(", ") { it.id }}"
+
+fun formatCopiedMessage(
+    destinationPath: Path,
+    ids: List<VulnId>,
+): String =
+    if (ids.isEmpty()) {
+        "No new vulnerabilities to copy to $destinationPath"
+    } else {
+        "Copied to $destinationPath: ${ids.joinToString(", ") { it.id }}"
+    }
 
 /**
  * Identifies vulnerability IDs from a given list that do not exist in the list of known vulnerabilities.
@@ -30,7 +87,7 @@ fun findNonExistingVulnIds(
  * @param releases The list of release entries to search. Releases with a null publication date are considered unpublished.
  * @return The most recently published release or the last entry if no release has been published.
  */
-fun latestPublishedRelease(releases: List<ReleaseEntry>): Release =
+fun lastReleaseFavoringPublished(releases: List<ReleaseEntry>): Release =
     releases.lastOrNull { it.publicationDate != null }?.id ?: releases.last().id
 
 /**

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/CopyTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/CopyTest.kt
@@ -2,129 +2,535 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.vulnlog.lib.core
 
+import dev.vulnlog.lib.model.Project
+import dev.vulnlog.lib.model.Purl
 import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReleaseEntry
+import dev.vulnlog.lib.model.ReportEntry
+import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.SchemaVersion
+import dev.vulnlog.lib.model.Tag
+import dev.vulnlog.lib.model.Verdict
+import dev.vulnlog.lib.model.VexJustification
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.VulnerabilityEntry
+import dev.vulnlog.lib.model.VulnlogFile
 import dev.vulnlog.lib.parse.createYamlMapper
 import dev.vulnlog.lib.parse.v1.dto.ReportEntryDto
 import dev.vulnlog.lib.parse.v1.dto.VulnerabilityEntryDto
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Path
 import java.time.LocalDate
+
+private val release1 = Release("1.0.0")
+private val release2 = Release("2.0.0")
+private val cve1 = VulnId.Cve("CVE-2026-1234")
+private val cve2 = VulnId.Cve("CVE-2026-5678")
+private val ghsa1 = VulnId.Ghsa("GHSA-1234-5678-abcd")
+
+private fun vulnerability(
+    id: VulnId = cve1,
+    name: String? = null,
+    aliases: List<VulnId> = emptyList(),
+    releases: List<Release> = listOf(release2),
+    description: String? = null,
+    packages: List<Purl> = listOf(Purl.Npm("pkg:npm/example-lib@2.3.0")),
+    reports: List<ReportEntry> = listOf(ReportEntry(reporter = ReporterType.TRIVY)),
+    tags: List<Tag> = emptyList(),
+    analysis: String? = null,
+    analyzedAt: LocalDate? = null,
+    verdict: Verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
+) = VulnerabilityEntry(
+    id = id,
+    name = name,
+    aliases = aliases,
+    releases = releases,
+    description = description,
+    packages = packages,
+    reports = reports,
+    tags = tags,
+    analysis = analysis,
+    analyzedAt = analyzedAt,
+    verdict = verdict,
+)
+
+private fun vulnlogFile(
+    releases: List<ReleaseEntry> = listOf(ReleaseEntry(id = release1, publicationDate = LocalDate.of(2026, 1, 1))),
+    vulnerabilities: List<VulnerabilityEntry> = emptyList(),
+) = VulnlogFile(
+    schemaVersion = SchemaVersion(1, 0),
+    project = Project("Acme", "App", "Sec"),
+    releases = releases,
+    vulnerabilities = vulnerabilities,
+)
 
 class CopyTest :
     FunSpec({
 
-        test("latestPublishedRelease returns last published release") {
-            val releases =
-                listOf(
-                    ReleaseEntry(id = Release("1.0.0"), publicationDate = LocalDate.of(2025, 1, 1)),
-                    ReleaseEntry(id = Release("1.1.0"), publicationDate = LocalDate.of(2025, 6, 1)),
-                    ReleaseEntry(id = Release("1.2.0")),
-                )
+        context("lastReleaseFavoringPublished") {
 
-            lastReleaseFavoringPublished(releases) shouldBe Release("1.1.0")
+            test("returns last published release") {
+                val releases =
+                    listOf(
+                        ReleaseEntry(id = Release("1.0.0"), publicationDate = LocalDate.of(2025, 1, 1)),
+                        ReleaseEntry(id = Release("1.1.0"), publicationDate = LocalDate.of(2025, 6, 1)),
+                        ReleaseEntry(id = Release("1.2.0")),
+                    )
+
+                lastReleaseFavoringPublished(releases) shouldBe Release("1.1.0")
+            }
+
+            test("falls back to last release when none is published") {
+                val releases =
+                    listOf(
+                        ReleaseEntry(id = Release("1.0.0")),
+                        ReleaseEntry(id = Release("1.1.0")),
+                    )
+
+                lastReleaseFavoringPublished(releases) shouldBe Release("1.1.0")
+            }
         }
 
-        test("latestPublishedRelease returns null when no releases are published") {
-            val releases =
-                listOf(
-                    ReleaseEntry(id = Release("1.0.0")),
-                    ReleaseEntry(id = Release("1.1.0")),
-                )
+        context("findNonExistingVulnIds") {
 
-            lastReleaseFavoringPublished(releases) shouldBe Release("1.1.0")
+            test("returns the requested ids that are not present") {
+                val vulns = listOf(vulnerability(id = cve1), vulnerability(id = cve2))
+
+                val missing = findNonExistingVulnIds(vulns, setOf(cve1, ghsa1))
+
+                missing shouldBe setOf(ghsa1)
+            }
+
+            test("returns empty set when all requested ids exist") {
+                val vulns = listOf(vulnerability(id = cve1))
+                findNonExistingVulnIds(vulns, setOf(cve1)) shouldBe emptySet()
+            }
         }
 
-        test("serializeEntryYaml produces correctly indented YAML list item") {
-            val dto =
-                VulnerabilityEntryDto(
-                    id = "CVE-2026-1234",
-                    releases = listOf("1.0.0"),
-                    packages = listOf("pkg:npm/example-lib@2.3.0"),
-                    reports = listOf(ReportEntryDto(reporter = "trivy")),
-                    verdict = "not affected",
-                    justification = "vulnerable code not in execute path",
-                )
+        context("formatCopiedMessage") {
 
-            val yaml = serializeEntryYaml(dto, createYamlMapper())
+            test("renders copied ids when non-empty") {
+                formatCopiedMessage(Path.of("/tmp/x.vl.yaml"), listOf(cve1, cve2)) shouldBe
+                    "Copied to /tmp/x.vl.yaml: CVE-2026-1234, CVE-2026-5678"
+            }
 
-            yaml shouldContain "  - id: "
-            yaml shouldContain "    releases:"
-            yaml shouldContain "    verdict: "
-            yaml shouldNotContain "---"
+            test("renders no-op message when empty") {
+                formatCopiedMessage(Path.of("/tmp/x.vl.yaml"), emptyList()) shouldBe
+                    "No new vulnerabilities to copy to /tmp/x.vl.yaml"
+            }
         }
 
-        test("serializeEntryYaml omits null fields") {
-            val dto =
-                VulnerabilityEntryDto(
-                    id = "CVE-2026-1234",
-                    releases = listOf("1.0.0"),
-                    packages = listOf("pkg:npm/example-lib@2.3.0"),
-                    reports = listOf(ReportEntryDto(reporter = "trivy")),
-                )
+        context("formatVulnIdsNotInSourceMessage") {
 
-            val yaml = serializeEntryYaml(dto, createYamlMapper())
-
-            yaml shouldNotContain "verdict:"
-            yaml shouldNotContain "severity:"
-            yaml shouldNotContain "justification:"
-            yaml shouldNotContain "analysis:"
-            yaml shouldNotContain "description:"
-            yaml shouldNotContain "comment:"
-            yaml shouldNotContain "resolution:"
-            yaml shouldNotContain "source:"
-            yaml shouldNotContain "suppress:"
+            test("renders missing ids") {
+                formatVulnIdsNotInSourceMessage(setOf(cve1, ghsa1)) shouldContain
+                    "Vulnerability IDs not found in source file:"
+                formatVulnIdsNotInSourceMessage(setOf(cve1)) shouldContain "CVE-2026-1234"
+            }
         }
 
-        test("serializeEntryYaml omits empty lists") {
-            val dto =
-                VulnerabilityEntryDto(
-                    id = "CVE-2026-1234",
-                    releases = listOf("1.0.0"),
-                    packages = listOf("pkg:npm/example-lib@2.3.0"),
-                    reports = listOf(ReportEntryDto(reporter = "trivy")),
-                    aliases = emptyList(),
-                    tags = emptyList(),
-                )
+        context("serializeEntryYaml") {
 
-            val yaml = serializeEntryYaml(dto, createYamlMapper())
+            test("produces correctly indented YAML list item") {
+                val dto =
+                    VulnerabilityEntryDto(
+                        id = "CVE-2026-1234",
+                        releases = listOf("1.0.0"),
+                        packages = listOf("pkg:npm/example-lib@2.3.0"),
+                        reports = listOf(ReportEntryDto(reporter = "trivy")),
+                        verdict = "not affected",
+                        justification = "vulnerable code not in execute path",
+                    )
 
-            yaml shouldNotContain "aliases:"
-            yaml shouldNotContain "tags:"
-            yaml shouldNotContain "vuln_ids:"
+                val yaml = serializeEntryYaml(dto, createYamlMapper())
+
+                yaml shouldContain "  - id: "
+                yaml shouldContain "    releases:"
+                yaml shouldContain "    verdict: "
+                yaml shouldNotContain "---"
+            }
+
+            test("omits null fields") {
+                val dto =
+                    VulnerabilityEntryDto(
+                        id = "CVE-2026-1234",
+                        releases = listOf("1.0.0"),
+                        packages = listOf("pkg:npm/example-lib@2.3.0"),
+                        reports = listOf(ReportEntryDto(reporter = "trivy")),
+                    )
+
+                val yaml = serializeEntryYaml(dto, createYamlMapper())
+
+                yaml shouldNotContain "verdict:"
+                yaml shouldNotContain "severity:"
+                yaml shouldNotContain "justification:"
+                yaml shouldNotContain "analysis:"
+                yaml shouldNotContain "description:"
+                yaml shouldNotContain "comment:"
+                yaml shouldNotContain "resolution:"
+                yaml shouldNotContain "source:"
+                yaml shouldNotContain "suppress:"
+            }
+
+            test("omits empty lists") {
+                val dto =
+                    VulnerabilityEntryDto(
+                        id = "CVE-2026-1234",
+                        releases = listOf("1.0.0"),
+                        packages = listOf("pkg:npm/example-lib@2.3.0"),
+                        reports = listOf(ReportEntryDto(reporter = "trivy")),
+                        aliases = emptyList(),
+                        tags = emptyList(),
+                    )
+
+                val yaml = serializeEntryYaml(dto, createYamlMapper())
+
+                yaml shouldNotContain "aliases:"
+                yaml shouldNotContain "tags:"
+                yaml shouldNotContain "vuln_ids:"
+            }
         }
 
-        test("insertEntryAfterVulnerabilitiesHeader inserts after header") {
-            val fileContent =
+        context("insertEntryAfterVulnerabilitiesHeader") {
+
+            test("inserts after header") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: "CVE-2026-0001"
+                    """.trimMargin()
+                val entryYaml = "  - id: \"CVE-2026-9999\"\n    releases:\n      - \"1.0.0\""
+
+                val result = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
+
+                val lines = result.lines()
+                val headerIndex = lines.indexOf("vulnerabilities:")
+                lines[headerIndex + 2] shouldBe "  - id: \"CVE-2026-9999\""
+            }
+
+            test("handles empty vulnerabilities list") {
+                val fileContent = "vulnerabilities: []"
+                val entryYaml = "  - id: \"CVE-2026-9999\"\n    releases:\n      - \"1.0.0\""
+
+                val result = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
+
+                result shouldContain "vulnerabilities:"
+                result shouldNotContain "[]"
+                result shouldContain "CVE-2026-9999"
+            }
+        }
+
+        context("replaceEntryById") {
+
+            test("replaces a middle entry and preserves blank separators") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-0001
+                    |    releases: [ 1.0.0 ]
+                    |
+                    |  - id: CVE-2026-1234
+                    |    releases: [ 1.0.0 ]
+                    |    description: old
+                    |
+                    |  - id: CVE-2026-5678
+                    |    releases: [ 1.0.0 ]
+                    """.trimMargin()
+                val newEntry = "  - id: CVE-2026-1234\n    releases: [ 2.0.0 ]\n    description: new"
+
+                val result = replaceEntryById(fileContent, cve1, newEntry)
+
+                result shouldContain "description: new"
+                result shouldNotContain "description: old"
+                // separator blank lines kept on both sides
+                result shouldContain "    releases: [ 1.0.0 ]\n\n  - id: CVE-2026-1234"
+                result shouldContain "    description: new\n\n  - id: CVE-2026-5678"
+                // the other entries are untouched
+                result shouldContain "  - id: CVE-2026-0001"
+                result shouldContain "  - id: CVE-2026-5678"
+            }
+
+            test("replaces the last entry in the section") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-0001
+                    |    releases: [ 1.0.0 ]
+                    |
+                    |  - id: CVE-2026-1234
+                    |    releases: [ 1.0.0 ]
+                    |    description: old
+                    """.trimMargin()
+                val newEntry = "  - id: CVE-2026-1234\n    description: new"
+
+                val result = replaceEntryById(fileContent, cve1, newEntry)
+
+                result shouldContain "description: new"
+                result shouldNotContain "description: old"
+                result shouldContain "  - id: CVE-2026-0001"
+            }
+
+            test("matches a quoted id") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: "CVE-2026-1234"
+                    |    description: old
+                    """.trimMargin()
+                val newEntry = "  - id: \"CVE-2026-1234\"\n    description: new"
+
+                val result = replaceEntryById(fileContent, cve1, newEntry)
+
+                result shouldContain "description: new"
+                result shouldNotContain "description: old"
+            }
+
+            test("falls back to inserting when the id is not present") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-0001
+                    |    releases: [ 1.0.0 ]
+                    """.trimMargin()
+                val newEntry = "  - id: CVE-2026-1234\n    releases: [ 1.0.0 ]"
+
+                val result = replaceEntryById(fileContent, cve1, newEntry)
+
+                result shouldContain "CVE-2026-1234"
+                result shouldContain "CVE-2026-0001"
+            }
+
+            test("stops at the next top-level key when the entry is the last one") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-1234
+                    |    description: old
+                    |
+                    |something_else:
+                    |  key: value
+                    """.trimMargin()
+                val newEntry = "  - id: CVE-2026-1234\n    description: new"
+
+                val result = replaceEntryById(fileContent, cve1, newEntry)
+
+                result shouldContain "description: new"
+                result shouldNotContain "description: old"
+                result shouldContain "something_else:"
+                result shouldContain "  key: value"
+            }
+
+            test("does not match an id substring inside a description") {
+                val fileContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-0001
+                    |    description: see CVE-2026-1234 for context
+                    """.trimMargin()
+                val newEntry = "  - id: CVE-2026-1234\n    description: new"
+
+                val result = replaceEntryById(fileContent, cve1, newEntry)
+
+                // id wasn't found as a real entry → falls back to inserting after the header
+                result shouldContain "see CVE-2026-1234 for context"
+                result shouldContain "  - id: CVE-2026-1234"
+            }
+        }
+
+        context("copyVulnerabilities") {
+
+            val sourceContent =
                 """
                 |vulnerabilities:
-                |
-                |  - id: "CVE-2026-0001"
                 """.trimMargin()
-
-            val entryYaml = "  - id: \"CVE-2026-9999\"\n    releases:\n      - \"1.0.0\""
-
-            val result = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
-
-            val lines = result.lines()
-            val headerIndex = lines.indexOf("vulnerabilities:")
-            lines[headerIndex + 2] shouldBe "  - id: \"CVE-2026-9999\""
-        }
-
-        test("insertEntryAfterVulnerabilitiesHeader handles empty vulnerabilities list") {
-            val fileContent =
+            val destinationContentEmpty =
                 """
-                |vulnerabilities: []
+                |vulnerabilities:
                 """.trimMargin()
 
-            val entryYaml = "  - id: \"CVE-2026-9999\"\n    releases:\n      - \"1.0.0\""
+            test("inserts an entry that does not exist in the destination") {
+                val source =
+                    vulnlogFile(
+                        vulnerabilities = listOf(vulnerability(id = cve1, description = "from source")),
+                    )
+                val destination = vulnlogFile()
 
-            val result = insertEntryAfterVulnerabilitiesHeader(fileContent, entryYaml)
+                val outcome =
+                    copyVulnerabilities(
+                        source = source,
+                        destination = destination,
+                        destinationContent = destinationContentEmpty,
+                        vulnIds = setOf(cve1),
+                    )
 
-            result shouldContain "vulnerabilities:"
-            result shouldNotContain "[]"
-            result shouldContain "CVE-2026-9999"
+                outcome.copied shouldContainExactly listOf(cve1)
+                outcome.newContent shouldContain "CVE-2026-1234"
+                outcome.newContent shouldContain "from source"
+                // release rewritten to destination's latest published release (1.0.0)
+                outcome.newContent shouldContain "1.0.0"
+                outcome.newContent shouldNotContain "2.0.0"
+            }
+
+            test("merges with existing entry: existing scalars win, source fills nulls") {
+                val source =
+                    vulnlogFile(
+                        vulnerabilities =
+                            listOf(
+                                vulnerability(
+                                    id = cve1,
+                                    description = "source description",
+                                    analysis = "source analysis",
+                                    name = "source name",
+                                ),
+                            ),
+                    )
+                val destination =
+                    vulnlogFile(
+                        vulnerabilities =
+                            listOf(
+                                vulnerability(
+                                    id = cve1,
+                                    description = "existing description", // existing wins
+                                    analysis = null, // null in existing → falls back to source
+                                    name = null, // null in existing → falls back to source
+                                    releases = listOf(release1),
+                                ),
+                            ),
+                    )
+                val destinationContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-1234
+                    |    releases: [ 1.0.0 ]
+                    |    description: existing description
+                    |    packages: [ "pkg:npm/example-lib@2.3.0" ]
+                    |    reports:
+                    |      - reporter: trivy
+                    |    verdict: not affected
+                    |    justification: vulnerable code not in execute path
+                    """.trimMargin()
+
+                val outcome =
+                    copyVulnerabilities(
+                        source = source,
+                        destination = destination,
+                        destinationContent = destinationContent,
+                        vulnIds = setOf(cve1),
+                    )
+
+                outcome.copied shouldContainExactly listOf(cve1)
+                outcome.newContent shouldContain "existing description"
+                outcome.newContent shouldNotContain "source description"
+                outcome.newContent shouldContain "source analysis"
+                outcome.newContent shouldContain "source name"
+                // exactly one entry — replace, not duplicate
+                "CVE-2026-1234".toRegex().findAll(outcome.newContent).count() shouldBe 1
+            }
+
+            test("merges lists by union (aliases, packages, tags)") {
+                val source =
+                    vulnlogFile(
+                        vulnerabilities =
+                            listOf(
+                                vulnerability(
+                                    id = cve1,
+                                    aliases = listOf(ghsa1),
+                                    packages = listOf(Purl.Npm("pkg:npm/source-only@1.0")),
+                                ),
+                            ),
+                    )
+                val destination =
+                    vulnlogFile(
+                        vulnerabilities =
+                            listOf(
+                                vulnerability(
+                                    id = cve1,
+                                    aliases = emptyList(),
+                                    packages = listOf(Purl.Npm("pkg:npm/dest-only@1.0")),
+                                    releases = listOf(release1),
+                                ),
+                            ),
+                    )
+                val destinationContent =
+                    """
+                    |vulnerabilities:
+                    |
+                    |  - id: CVE-2026-1234
+                    |    releases: [ 1.0.0 ]
+                    |    packages: [ "pkg:npm/dest-only@1.0" ]
+                    |    reports:
+                    |      - reporter: trivy
+                    |    verdict: not affected
+                    |    justification: vulnerable code not in execute path
+                    """.trimMargin()
+
+                val outcome =
+                    copyVulnerabilities(
+                        source = source,
+                        destination = destination,
+                        destinationContent = destinationContent,
+                        vulnIds = setOf(cve1),
+                    )
+
+                // packages: union (existing first, then unique additions)
+                outcome.newContent shouldContain "pkg:npm/dest-only@1.0"
+                outcome.newContent shouldContain "pkg:npm/source-only@1.0"
+                // aliases: source's alias appears
+                outcome.newContent shouldContain "GHSA-1234-5678-abcd"
+            }
+
+            test("rewrites releases to destination's latest published release") {
+                val source =
+                    vulnlogFile(
+                        vulnerabilities = listOf(vulnerability(id = cve1, releases = listOf(release2))),
+                    )
+                val destination =
+                    vulnlogFile(
+                        releases =
+                            listOf(
+                                ReleaseEntry(id = release1, publicationDate = LocalDate.of(2025, 1, 1)),
+                                ReleaseEntry(id = Release("1.5.0")),
+                            ),
+                    )
+
+                val outcome =
+                    copyVulnerabilities(
+                        source = source,
+                        destination = destination,
+                        destinationContent = destinationContentEmpty,
+                        vulnIds = setOf(cve1),
+                    )
+
+                outcome.newContent shouldContain "\"1.0.0\""
+                outcome.newContent shouldNotContain "1.5.0"
+                outcome.newContent shouldNotContain "2.0.0"
+            }
+
+            test("ignores ids in vulnIds that are not present in the source") {
+                val source = vulnlogFile(vulnerabilities = listOf(vulnerability(id = cve1)))
+
+                val outcome =
+                    copyVulnerabilities(
+                        source = source,
+                        destination = vulnlogFile(),
+                        destinationContent = destinationContentEmpty,
+                        vulnIds = setOf(cve2), // not in source
+                    )
+
+                outcome.copied shouldBe emptyList()
+                outcome.newContent shouldNotContain "CVE-2026-5678"
+            }
         }
     })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/CopyTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/CopyTest.kt
@@ -34,7 +34,7 @@ class CopyTest :
                     ReleaseEntry(id = Release("1.1.0")),
                 )
 
-            latestPublishedRelease(releases) shouldBe null
+            latestPublishedRelease(releases) shouldBe Release("1.1.0")
         }
 
         test("serializeEntryYaml produces correctly indented YAML list item") {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/CopyTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/CopyTest.kt
@@ -24,7 +24,7 @@ class CopyTest :
                     ReleaseEntry(id = Release("1.2.0")),
                 )
 
-            latestPublishedRelease(releases) shouldBe Release("1.1.0")
+            lastReleaseFavoringPublished(releases) shouldBe Release("1.1.0")
         }
 
         test("latestPublishedRelease returns null when no releases are published") {
@@ -34,7 +34,7 @@ class CopyTest :
                     ReleaseEntry(id = Release("1.1.0")),
                 )
 
-            latestPublishedRelease(releases) shouldBe Release("1.1.0")
+            lastReleaseFavoringPublished(releases) shouldBe Release("1.1.0")
         }
 
         test("serializeEntryYaml produces correctly indented YAML list item") {


### PR DESCRIPTION
When working with multiple Vulnlog files, the new `vulnlog modify copy src des` command helps you copy one or more vulnerability entries to one or more destination files.

See `vulnlog modify copy --help`