### PR TITLE
feat: Refine HTML report and add more infromation

### DIFF
--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ReportCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ReportCommand.kt
@@ -14,15 +14,18 @@ import com.github.ajalt.clikt.parameters.options.OptionCallTransformContext
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
+import dev.vulnlog.cli.BuildInfo
+import dev.vulnlog.lib.core.canonical
 import dev.vulnlog.lib.core.collectReportingEntries
 import dev.vulnlog.lib.core.mergeReportingEntries
 import dev.vulnlog.lib.core.validateSharedProject
 import dev.vulnlog.lib.parse.reporting.HtmlReportMapper.toDto
 import dev.vulnlog.lib.parse.reporting.HtmlReportWriter.renderHtmlReport
+import dev.vulnlog.lib.parse.reporting.dto.FilterDataDto
 import dev.vulnlog.lib.shell.FileInputOption
 import dev.vulnlog.lib.shell.FileOutputOption
 import java.nio.file.Path
-import java.time.LocalDate
+import java.time.Instant
 
 class ReportCommand : CliktCommand(name = "report") {
     override fun help(context: Context): String = "Generate a vulnerability report."
@@ -60,7 +63,23 @@ class ReportCommand : CliktCommand(name = "report") {
             vulnlogFiles.flatMap { collectReportingEntries(it, filter) }
         val merged = mergeReportingEntries(allEntries)
 
-        val reportData = toDto(project, merged, LocalDate.now())
+        val filterData =
+            FilterDataDto(
+                release = filterOptions.releaseOption,
+                tags = filterOptions.tagsOptions.sorted(),
+                reporter = filterOptions.reporter?.canonical(),
+            )
+        val inputNames = parsedSuccessfully.keys.map { it.name }
+
+        val reportData =
+            toDto(
+                project = project,
+                entries = merged,
+                generatedAt = Instant.now(),
+                vulnlogVersion = BuildInfo.VERSION,
+                inputs = inputNames,
+                filter = filterData,
+            )
         val content = renderHtmlReport(reportData)
 
         when (val target = output) {

--- a/modules/gradle-plugin/build.gradle.kts
+++ b/modules/gradle-plugin/build.gradle.kts
@@ -27,6 +27,36 @@ dependencies {
     testImplementation(libs.kotestRunnerJunit5Jvm)
 }
 
+val generateBuildInfo by tasks.registering {
+    val versionValue = project.version.toString()
+    val outputDir = layout.buildDirectory.dir("generated/source/buildInfo")
+
+    inputs.property("version", versionValue)
+    outputs.dir(outputDir)
+
+    doLast {
+        val buildInfoFile = outputDir.get().file("dev/vulnlog/gradle/BuildInfo.kt").asFile
+        buildInfoFile.parentFile.mkdirs()
+        buildInfoFile.writeText(
+            """
+            package dev.vulnlog.gradle
+
+            internal object BuildInfo {
+                const val VERSION = "$versionValue"
+            }
+            """.trimIndent() + "\n",
+        )
+    }
+}
+
+kotlin {
+    sourceSets {
+        main {
+            kotlin.srcDir(generateBuildInfo)
+        }
+    }
+}
+
 tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
     configurations = listOf(shaded)

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
@@ -6,11 +6,14 @@ import dev.vulnlog.gradle.internal.buildFilterOrFail
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
+import dev.vulnlog.lib.core.canonical
 import dev.vulnlog.lib.core.collectReportingEntries
 import dev.vulnlog.lib.core.mergeReportingEntries
+import dev.vulnlog.lib.core.parseReporter
 import dev.vulnlog.lib.core.validateSharedProject
 import dev.vulnlog.lib.parse.reporting.HtmlReportMapper
 import dev.vulnlog.lib.parse.reporting.HtmlReportWriter
+import dev.vulnlog.lib.parse.reporting.dto.FilterDataDto
 import dev.vulnlog.lib.result.ParseResult
 import dev.vulnlog.lib.shell.FileInputOption
 import org.gradle.api.DefaultTask
@@ -27,7 +30,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.time.LocalDate
+import java.time.Instant
 
 @CacheableTask
 abstract class VulnlogReportTask : DefaultTask() {
@@ -67,7 +70,23 @@ abstract class VulnlogReportTask : DefaultTask() {
         val allEntries = vulnlogFiles.flatMap { collectReportingEntries(it, filter) }
         val merged = mergeReportingEntries(allEntries)
 
-        val reportData = HtmlReportMapper.toDto(project, merged, LocalDate.now())
+        val filterData =
+            FilterDataDto(
+                release = release.orNull,
+                tags = tags.get().sorted(),
+                reporter = reporter.orNull?.let { parseReporter(it).canonical() },
+            )
+        val inputNames = parsedSuccessfully.keys.map { it.name }
+
+        val reportData =
+            HtmlReportMapper.toDto(
+                project = project,
+                entries = merged,
+                generatedAt = Instant.now(),
+                vulnlogVersion = BuildInfo.VERSION,
+                inputs = inputNames,
+                filter = filterData,
+            )
         val reportContent = HtmlReportWriter.renderHtmlReport(reportData)
 
         val out = outputFile.get().asFile

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/HtmlReportMapper.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/HtmlReportMapper.kt
@@ -3,19 +3,24 @@
 package dev.vulnlog.lib.parse.reporting
 
 import dev.vulnlog.lib.model.Project
+import dev.vulnlog.lib.model.Severity
 import dev.vulnlog.lib.model.report.Impact
 import dev.vulnlog.lib.model.report.ReportingEntry
+import dev.vulnlog.lib.model.report.WorkState
+import dev.vulnlog.lib.parse.reporting.dto.FilterDataDto
 import dev.vulnlog.lib.parse.reporting.dto.ProjectDataDto
 import dev.vulnlog.lib.parse.reporting.dto.ReportDataDto
 import dev.vulnlog.lib.parse.reporting.dto.ReportEntryDataDto
-import java.time.LocalDate
-import kotlin.collections.map
+import java.time.Instant
 
 object HtmlReportMapper {
     fun toDto(
         project: Project,
         entries: List<ReportingEntry>,
-        generatedAt: LocalDate,
+        generatedAt: Instant,
+        vulnlogVersion: String,
+        inputs: List<String>,
+        filter: FilterDataDto,
     ): ReportDataDto =
         ReportDataDto(
             project =
@@ -25,8 +30,16 @@ object HtmlReportMapper {
                     author = project.author,
                 ),
             generatedAt = generatedAt.toString(),
-            entries = entries.map(::toReportEntryData),
+            vulnlogVersion = vulnlogVersion,
+            inputs = inputs,
+            filter = filter,
+            entries = entries.sortedWith(entrySortComparator).map(::toReportEntryData),
         )
+
+    private val entrySortComparator: Comparator<ReportingEntry> =
+        compareBy<ReportingEntry> { stateOrder(it.state) }
+            .thenBy { severityOrder(severityOf(it.impact)) }
+            .thenBy { it.primaryId.id }
 
     private fun toReportEntryData(entry: ReportingEntry): ReportEntryDataDto =
         ReportEntryDataDto(
@@ -50,19 +63,38 @@ object HtmlReportMapper {
             is Impact.Unknown -> "under_investigation"
         }
 
-    private fun severityLabel(impact: Impact): String? =
+    private fun severityOf(impact: Impact): Severity? =
         when (impact) {
-            is Impact.Affected -> impact.severity.name.lowercase()
-            is Impact.AcceptableRisk -> impact.severity.name.lowercase()
+            is Impact.Affected -> impact.severity
+            is Impact.AcceptableRisk -> impact.severity
             is Impact.NotAffected -> null
             is Impact.Unknown -> null
         }
 
+    private fun severityLabel(impact: Impact): String? = severityOf(impact)?.name?.lowercase()
+
     private fun verdictDetail(impact: Impact): String? =
         when (impact) {
             is Impact.NotAffected -> impact.reason
-            is Impact.AcceptableRisk -> impact.severity.name.lowercase()
-            is Impact.Affected -> impact.severity.name.lowercase()
+            is Impact.AcceptableRisk -> null
+            is Impact.Affected -> null
             is Impact.Unknown -> null
+        }
+
+    private fun stateOrder(state: WorkState): Int =
+        when (state) {
+            WorkState.OPEN -> 0
+            WorkState.UNDER_INVESTIGATION -> 1
+            WorkState.RESOLVED -> 2
+            WorkState.DISMISSED -> 3
+        }
+
+    private fun severityOrder(severity: Severity?): Int =
+        when (severity) {
+            Severity.CRITICAL -> 0
+            Severity.HIGH -> 1
+            Severity.MEDIUM -> 2
+            Severity.LOW -> 3
+            null -> 4
         }
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/dto/FilterDataDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/dto/FilterDataDto.kt
@@ -1,0 +1,9 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.lib.parse.reporting.dto
+
+data class FilterDataDto(
+    val release: String?,
+    val tags: List<String>,
+    val reporter: String?,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/dto/ReportDataDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/dto/ReportDataDto.kt
@@ -5,5 +5,8 @@ package dev.vulnlog.lib.parse.reporting.dto
 data class ReportDataDto(
     val project: ProjectDataDto,
     val generatedAt: String,
+    val vulnlogVersion: String,
+    val inputs: List<String>,
+    val filter: FilterDataDto,
     val entries: List<ReportEntryDataDto>,
 )

--- a/modules/lib/src/main/resources/META-INF/native-image/dev.vulnlog/lib/reflect-config.json
+++ b/modules/lib/src/main/resources/META-INF/native-image/dev.vulnlog/lib/reflect-config.json
@@ -90,6 +90,12 @@
     "allDeclaredMethods": true
   },
   {
+    "name": "dev.vulnlog.lib.parse.reporting.dto.FilterDataDto",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "dev.vulnlog.lib.parse.reporting.dto.ProjectDataDto",
     "allDeclaredFields": true,
     "allDeclaredConstructors": true,

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportGoldenTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportGoldenTest.kt
@@ -1,0 +1,97 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.lib.render
+
+import dev.vulnlog.lib.model.Project
+import dev.vulnlog.lib.model.Release
+import dev.vulnlog.lib.model.Severity
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.report.Impact
+import dev.vulnlog.lib.model.report.ReportingEntry
+import dev.vulnlog.lib.model.report.WorkState
+import dev.vulnlog.lib.parse.reporting.HtmlReportMapper.toDto
+import dev.vulnlog.lib.parse.reporting.HtmlReportWriter.renderHtmlReport
+import dev.vulnlog.lib.parse.reporting.dto.FilterDataDto
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+private const val GOLDEN_RESOURCE = "/report/golden-vulnlog-report-simple.html"
+private val GOLDEN_SOURCE: Path = Path.of("src/test/resources/report/golden-vulnlog-report-simple.html")
+
+class HtmlReportGoldenTest :
+    FunSpec({
+        test("matches golden HTML snapshot") {
+            val actual = renderHtmlReport(goldenFixture())
+
+            if (shouldUpdateGolden()) {
+                Files.createDirectories(GOLDEN_SOURCE.parent)
+                Files.writeString(GOLDEN_SOURCE, actual)
+                println("Golden HTML updated at $GOLDEN_SOURCE")
+                return@test
+            }
+
+            val expected =
+                HtmlReportGoldenTest::class.java
+                    .getResourceAsStream(GOLDEN_RESOURCE)
+                    ?.bufferedReader()
+                    ?.use { it.readText() }
+                    ?: error(
+                        "Golden HTML missing at classpath $GOLDEN_RESOURCE. " +
+                            "Run with UPDATE_GOLDEN=1 to create it.",
+                    )
+
+            actual shouldBe expected
+        }
+    })
+
+private fun shouldUpdateGolden(): Boolean = System.getenv("UPDATE_GOLDEN") in listOf("1", "true")
+
+private fun goldenFixture() =
+    toDto(
+        project = Project("Acme Corp", "Acme Web App", "Security Team"),
+        entries =
+            listOf(
+                ReportingEntry(
+                    primaryId = VulnId.Cve("CVE-2026-1111"),
+                    state = WorkState.OPEN,
+                    ids = setOf(VulnId.Cve("CVE-2026-1111"), VulnId.Ghsa("GHSA-aaaa-bbbb-cccc")),
+                    shortDescription = "Critical RCE in example-lib",
+                    impact = Impact.Affected(Severity.CRITICAL),
+                    analysis = "Confirmed exploitable on the public ingress path; patch in progress.",
+                    reportFor = setOf(Release("1.0.0"), Release("1.1.0")),
+                    fixedIn = setOf(Release("1.2.0")),
+                ),
+                ReportingEntry(
+                    primaryId = VulnId.Cve("CVE-2026-2222"),
+                    state = WorkState.OPEN,
+                    ids = setOf(VulnId.Cve("CVE-2026-2222")),
+                    shortDescription = null,
+                    impact = Impact.NotAffected("vulnerable code not in execute path"),
+                    analysis = null,
+                    reportFor = setOf(Release("1.1.0")),
+                    fixedIn = emptySet(),
+                ),
+                ReportingEntry(
+                    primaryId = VulnId.Cve("CVE-2026-3333"),
+                    state = WorkState.RESOLVED,
+                    ids = setOf(VulnId.Cve("CVE-2026-3333")),
+                    shortDescription = "DoS via large payload",
+                    impact = Impact.Affected(Severity.MEDIUM),
+                    analysis = "Mitigated by request size limits at the edge.",
+                    reportFor = setOf(Release("1.0.0")),
+                    fixedIn = setOf(Release("1.0.1")),
+                ),
+            ),
+        generatedAt = Instant.parse("2026-05-02T10:30:00Z"),
+        vulnlogVersion = "1.2.3-test",
+        inputs = listOf("frontend.vl", "backend.vl"),
+        filter =
+            FilterDataDto(
+                release = "1.1.0",
+                tags = listOf("production"),
+                reporter = "trivy",
+            ),
+    )

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportRendererTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportRendererTest.kt
@@ -11,13 +11,16 @@ import dev.vulnlog.lib.model.report.ReportingEntry
 import dev.vulnlog.lib.model.report.WorkState
 import dev.vulnlog.lib.parse.reporting.HtmlReportMapper.toDto
 import dev.vulnlog.lib.parse.reporting.HtmlReportWriter.renderHtmlReport
+import dev.vulnlog.lib.parse.reporting.dto.FilterDataDto
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
-import java.time.LocalDate
+import java.time.Instant
 
 private val defaultProject = Project("Acme Corp", "Acme Web App", "Security Team")
-private val defaultDate = LocalDate.of(2026, 1, 15)
+private val defaultInstant: Instant = Instant.parse("2026-01-15T10:30:00Z")
+private const val DEFAULT_VERSION = "1.2.3"
+private val emptyFilter = FilterDataDto(release = null, tags = emptyList(), reporter = null)
 
 private fun entry(
     primaryId: VulnId = VulnId.Cve("CVE-2026-1234"),
@@ -39,22 +42,36 @@ private fun entry(
     fixedIn = fixedIn,
 )
 
+private fun render(
+    entries: List<ReportingEntry>,
+    generatedAt: Instant = defaultInstant,
+    vulnlogVersion: String = DEFAULT_VERSION,
+    inputs: List<String> = listOf("vulnlog.vl"),
+    filter: FilterDataDto = emptyFilter,
+): String =
+    renderHtmlReport(
+        toDto(
+            project = defaultProject,
+            entries = entries,
+            generatedAt = generatedAt,
+            vulnlogVersion = vulnlogVersion,
+            inputs = inputs,
+            filter = filter,
+        ),
+    )
+
 class HtmlReportRendererTest :
     FunSpec({
 
         test("renders valid HTML with project name") {
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = listOf(entry()))
-
-            val html = renderHtmlReport(data)
+            val html = render(listOf(entry()))
 
             html shouldContain "<!DOCTYPE html>"
             html shouldContain "Acme Web App"
         }
 
         test("contains serialized entry data") {
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = listOf(entry()))
-
-            val html = renderHtmlReport(data)
+            val html = render(listOf(entry()))
 
             html shouldContain "CVE-2026-1234"
             html shouldContain "affected"
@@ -62,17 +79,13 @@ class HtmlReportRendererTest :
         }
 
         test("placeholder is replaced") {
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = listOf(entry()))
-
-            val html = renderHtmlReport(data)
+            val html = render(listOf(entry()))
 
             html shouldNotContain "VULNLOG_DATA_PLACEHOLDER"
         }
 
         test("renders with empty entries") {
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = emptyList())
-
-            val html = renderHtmlReport(data)
+            val html = render(emptyList())
 
             html shouldContain "<!DOCTYPE html>"
             html shouldContain "\"entries\":[]"
@@ -88,9 +101,7 @@ class HtmlReportRendererTest :
                         state = WorkState.OPEN,
                     ),
                 )
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = entries)
-
-            val html = renderHtmlReport(data)
+            val html = render(entries)
 
             html shouldContain "CVE-2026-1234"
             html shouldContain "CVE-2026-5678"
@@ -103,21 +114,102 @@ class HtmlReportRendererTest :
                     primaryId = VulnId.Cve("CVE-2026-1234"),
                     ids = setOf(VulnId.Cve("CVE-2026-1234"), VulnId.Ghsa("GHSA-abcd-1234-efgh")),
                 )
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = listOf(e))
-
-            val html = renderHtmlReport(data)
+            val html = render(listOf(e))
 
             html shouldContain "GHSA-abcd-1234-efgh"
         }
 
         test("includes fix releases in serialized data") {
-            val e =
-                entry(fixedIn = setOf(Release("1.1.0"), Release("2.0.1")))
-            val data = toDto(defaultProject, generatedAt = defaultDate, entries = listOf(e))
-
-            val html = renderHtmlReport(data)
+            val e = entry(fixedIn = setOf(Release("1.1.0"), Release("2.0.1")))
+            val html = render(listOf(e))
 
             html shouldContain "1.1.0"
             html shouldContain "2.0.1"
+        }
+
+        test("includes vulnlog version") {
+            val html = render(listOf(entry()), vulnlogVersion = "9.9.9-test")
+
+            html shouldContain "9.9.9-test"
+        }
+
+        test("includes input file names") {
+            val html = render(listOf(entry()), inputs = listOf("project.vl", "deps.vl"))
+
+            html shouldContain "project.vl"
+            html shouldContain "deps.vl"
+        }
+
+        test("includes applied filter") {
+            val html =
+                render(
+                    listOf(entry()),
+                    filter =
+                        FilterDataDto(
+                            release = "1.2.0",
+                            tags = listOf("frontend", "production"),
+                            reporter = "trivy",
+                        ),
+                )
+
+            html shouldContain "1.2.0"
+            html shouldContain "frontend"
+            html shouldContain "trivy"
+        }
+
+        test("includes verdictDetail for not-affected entries") {
+            val e =
+                entry(
+                    impact = Impact.NotAffected("vulnerable code not in execute path"),
+                )
+            val html = render(listOf(e))
+
+            html shouldContain "vulnerable code not in execute path"
+        }
+
+        test("renders generatedAt as ISO instant") {
+            val html = render(listOf(entry()), generatedAt = Instant.parse("2026-05-02T08:15:30Z"))
+
+            html shouldContain "2026-05-02T08:15:30Z"
+        }
+
+        test("includes Content-Security-Policy meta tag") {
+            val html = render(listOf(entry()))
+
+            html shouldContain "Content-Security-Policy"
+            html shouldContain "default-src 'none'"
+        }
+
+        test("sorts entries by state then severity") {
+            val entries =
+                listOf(
+                    entry(
+                        primaryId = VulnId.Cve("CVE-2026-0001"),
+                        state = WorkState.RESOLVED,
+                        impact = Impact.Affected(Severity.LOW),
+                    ),
+                    entry(
+                        primaryId = VulnId.Cve("CVE-2026-0002"),
+                        state = WorkState.OPEN,
+                        impact = Impact.Affected(Severity.MEDIUM),
+                    ),
+                    entry(
+                        primaryId = VulnId.Cve("CVE-2026-0003"),
+                        state = WorkState.OPEN,
+                        impact = Impact.Affected(Severity.CRITICAL),
+                    ),
+                )
+            val html = render(entries)
+
+            // Critical-open should appear before medium-open, both before low-resolved.
+            val criticalIdx = html.indexOf("CVE-2026-0003")
+            val mediumIdx = html.indexOf("CVE-2026-0002")
+            val resolvedIdx = html.indexOf("CVE-2026-0001")
+            check(criticalIdx in 0..<mediumIdx) {
+                "Expected CVE-2026-0003 (open critical) before CVE-2026-0002 (open medium)"
+            }
+            check(mediumIdx in 0..<resolvedIdx) {
+                "Expected CVE-2026-0002 (open) before CVE-2026-0001 (resolved)"
+            }
         }
     })

--- a/modules/lib/src/test/resources/report/golden-vulnlog-report-simple.html
+++ b/modules/lib/src/test/resources/report/golden-vulnlog-report-simple.html
@@ -549,7 +549,7 @@
 </footer>
 
 <script>
-    var VULNLOG_DATA = /*VULNLOG_DATA_PLACEHOLDER*/;
+    var VULNLOG_DATA = {"project":{"organization":"Acme Corp","name":"Acme Web App","author":"Security Team"},"generatedAt":"2026-05-02T10:30:00Z","vulnlogVersion":"1.2.3-test","inputs":["frontend.vl","backend.vl"],"filter":{"release":"1.1.0","tags":["production"],"reporter":"trivy"},"entries":[{"primaryId":"CVE-2026-1111","ids":["CVE-2026-1111","GHSA-aaaa-bbbb-cccc"],"state":"open","verdict":"affected","severity":"critical","verdictDetail":null,"shortDescription":"Critical RCE in example-lib","analysis":"Confirmed exploitable on the public ingress path; patch in progress.","releases":["1.0.0","1.1.0"],"fixedIn":["1.2.0"]},{"primaryId":"CVE-2026-2222","ids":["CVE-2026-2222"],"state":"open","verdict":"not affected","severity":null,"verdictDetail":"vulnerable code not in execute path","shortDescription":null,"analysis":null,"releases":["1.1.0"],"fixedIn":[]},{"primaryId":"CVE-2026-3333","ids":["CVE-2026-3333"],"state":"resolved","verdict":"affected","severity":"medium","verdictDetail":null,"shortDescription":"DoS via large payload","analysis":"Mitigated by request size limits at the edge.","releases":["1.0.0"],"fixedIn":["1.0.1"]}]};
     (function () {
         var COLUMN_META = {
             ids: {label: 'IDs', width: '16%', tooltip: 'Vulnerability identifiers (CVE, GHSA, SNYK)'},


### PR DESCRIPTION
- add information about how the report was generated
- add simple summary of the content of the report
- shrink to only four columns to reduce visual noise
- move logo to footer and add CLI generator version