### PR TITLE
feat: add cargo-audit native suppression file generation (#72)

### DIFF
--- a/docs/modules/ROOT/examples/suppress/Cargo Audit Suppression Example.toml
+++ b/docs/modules/ROOT/examples/suppress/Cargo Audit Suppression Example.toml
@@ -1,0 +1,5 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0001",
+    "RUSTSEC-2021-0073",
+]

--- a/docs/modules/ROOT/pages/cli-suppress.adoc
+++ b/docs/modules/ROOT/pages/cli-suppress.adoc
@@ -66,3 +66,9 @@ include::{examplesdir}/suppress/Snyk Suppression Example.yaml[lines=1..5]
 ----
 include::{examplesdir}/suppress/Trivy Suppression Example.yaml[lines=1..4]
 ----
+
+.Generated Cargo Audit suppression file
+[source,toml]
+----
+include::{examplesdir}/suppress/Cargo Audit Suppression Example.toml[]
+----

--- a/docs/modules/ROOT/pages/suppression.adoc
+++ b/docs/modules/ROOT/pages/suppression.adoc
@@ -128,8 +128,8 @@ The CLI determines which identifiers to write into the suppression file using th
 
 | `cargo-audit`
 | Cargo Audit (Rust)
-| `.cargo-audit.toml`
-| Planned
+| `audit.toml`
+| Yes (RUSTSEC IDs only)
 
 | `semgrep`
 | Semgrep

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
@@ -102,7 +102,7 @@ private fun getDefaultSettingsForReporter(reporter: ReporterType): Suppression =
         ReporterType.GRYPE -> Suppressable.GenericFormat.Generic(reporter)
         ReporterType.NPM_AUDIT -> Suppressable.GenericFormat.Generic(reporter)
         ReporterType.OTHER -> NotSuppressable
-        ReporterType.CARGO_AUDIT -> Suppressable.GenericFormat.Generic(reporter)
+        ReporterType.CARGO_AUDIT -> Suppressable.NativeFormat.CargoAudit
         ReporterType.SEMGREP -> Suppressable.GenericFormat.Generic(reporter)
         ReporterType.SNYK -> Suppressable.NativeFormat.Snyk
         ReporterType.TRIVY -> Suppressable.NativeFormat.Trivy
@@ -116,6 +116,7 @@ private fun createSuppression(
         is Suppressable.GenericFormat.Generic -> createGenericSuppression(defaults, suppressions)
         is Suppressable.NativeFormat.Trivy -> createTrivySuppression(defaults, suppressions)
         is Suppressable.NativeFormat.Snyk -> createSnykSuppression(defaults, suppressions)
+        is Suppressable.NativeFormat.CargoAudit -> createCargoAuditSuppression(defaults, suppressions)
     }
 
 private fun createGenericSuppression(
@@ -153,6 +154,18 @@ private fun createTrivySuppression(
                 )
             }.toSet()
     return SuppressionOutput.TrivySuppression(entries = entries)
+}
+
+private fun createCargoAuditSuppression(
+    defaults: Suppressable.NativeFormat.CargoAudit,
+    suppressions: List<SuppressedVulnerability>,
+): SuppressionOutput {
+    val entries =
+        suppressions
+            .filter { suppression -> suppression.id::class in defaults.vulnIdTypes }
+            .map { suppression -> SuppressionVuln.CargoAuditSuppressionEntry(id = suppression.id) }
+            .toSet()
+    return SuppressionOutput.CargoAuditSuppression(entries = entries)
 }
 
 private fun createSnykSuppression(

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/ReporterDefaults.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/ReporterDefaults.kt
@@ -32,5 +32,10 @@ sealed interface Suppressable : Suppression {
             override val vulnIdTypes: Set<KClass<out VulnId>>
                 get() = setOf(VulnId.Snyk::class)
         }
+
+        data object CargoAudit : Suppressable {
+            override val vulnIdTypes: Set<KClass<out VulnId>>
+                get() = setOf(VulnId.RustSec::class)
+        }
     }
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/SuppressedVulnerability.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/SuppressedVulnerability.kt
@@ -32,6 +32,11 @@ sealed interface SuppressionOutput {
         val fileName: String = ".snyk",
         val entries: Set<SuppressionVuln.SnykSuppressionEntry>,
     ) : SuppressionOutput
+
+    data class CargoAuditSuppression(
+        val fileName: String = "audit.toml",
+        val entries: Set<SuppressionVuln.CargoAuditSuppressionEntry>,
+    ) : SuppressionOutput
 }
 
 sealed interface SuppressionVuln {
@@ -51,5 +56,9 @@ sealed interface SuppressionVuln {
         val id: VulnId,
         val expiresAt: LocalDate? = null,
         val reason: String,
+    ) : SuppressionVuln
+
+    data class CargoAuditSuppressionEntry(
+        val id: VulnId,
     ) : SuppressionVuln
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/SuppressionWriter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/SuppressionWriter.kt
@@ -3,6 +3,7 @@
 package dev.vulnlog.lib.parse.suppression
 
 import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.parse.suppression.cargoaudit.CargoAuditSuppressionWriter
 import dev.vulnlog.lib.parse.suppression.generic.GenericSuppressionWriter
 import dev.vulnlog.lib.parse.suppression.snyk.SnykSuppressionWriter
 import dev.vulnlog.lib.parse.suppression.trivy.TrivySuppressionWriter
@@ -31,6 +32,12 @@ object SuppressionWriter {
                 SuppressionFile(
                     fileName = output.fileName,
                     content = SnykSuppressionWriter.write(output),
+                )
+
+            is SuppressionOutput.CargoAuditSuppression ->
+                SuppressionFile(
+                    fileName = output.fileName,
+                    content = CargoAuditSuppressionWriter.write(output),
                 )
         }
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/cargoaudit/CargoAuditSuppressionWriter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/cargoaudit/CargoAuditSuppressionWriter.kt
@@ -1,0 +1,13 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.lib.parse.suppression.cargoaudit
+
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+
+object CargoAuditSuppressionWriter {
+    fun write(inputData: SuppressionOutput.CargoAuditSuppression): String {
+        if (inputData.entries.isEmpty()) return "[advisories]\nignore = []\n"
+        val ids = inputData.entries.joinToString(",\n") { "    \"${it.id.id}\"" }
+        return "[advisories]\nignore = [\n$ids,\n]\n"
+    }
+}

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/cargoaudit/CargoAuditSuppressionWriterTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/cargoaudit/CargoAuditSuppressionWriterTest.kt
@@ -1,0 +1,67 @@
+// Copyright 2024 the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+package dev.vulnlog.lib.parse.suppression.cargoaudit
+
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.model.suppress.SuppressionVuln
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CargoAuditSuppressionWriterTest :
+    FunSpec({
+
+        test("writes single RUSTSEC entry") {
+            val input =
+                SuppressionOutput.CargoAuditSuppression(
+                    entries =
+                        setOf(
+                            SuppressionVuln.CargoAuditSuppressionEntry(
+                                id = VulnId.RustSec("RUSTSEC-2024-0001"),
+                            ),
+                        ),
+                )
+
+            val result = CargoAuditSuppressionWriter.write(input)
+
+            result shouldBe
+                """
+                [advisories]
+                ignore = [
+                    "RUSTSEC-2024-0001",
+                ]
+
+                """.trimIndent()
+        }
+
+        test("writes multiple entries") {
+            val input =
+                SuppressionOutput.CargoAuditSuppression(
+                    entries =
+                        setOf(
+                            SuppressionVuln.CargoAuditSuppressionEntry(id = VulnId.RustSec("RUSTSEC-2024-0001")),
+                            SuppressionVuln.CargoAuditSuppressionEntry(id = VulnId.RustSec("RUSTSEC-2021-0073")),
+                        ),
+                )
+
+            val result = CargoAuditSuppressionWriter.write(input)
+
+            result shouldBe
+                """
+                [advisories]
+                ignore = [
+                    "RUSTSEC-2024-0001",
+                    "RUSTSEC-2021-0073",
+                ]
+
+                """.trimIndent()
+        }
+
+        test("writes empty ignore list") {
+            val input = SuppressionOutput.CargoAuditSuppression(entries = emptySet())
+
+            val result = CargoAuditSuppressionWriter.write(input)
+
+            result shouldBe "[advisories]\nignore = []\n"
+        }
+    })


### PR DESCRIPTION
Generates audit.toml suppression files for cargo audit.