### PR TITLE
feat: Add release-aware filtering for suppress and report commands

### DIFF
--- a/docs/modules/ROOT/pages/cli-report.adoc
+++ b/docs/modules/ROOT/pages/cli-report.adoc
@@ -22,6 +22,7 @@ Use `-` as a file argument to read from stdin and `-o -` to write the report to 
 
 | `--release <text>`
 | Filter on release, include all releases up to and including that release.
+A vulnerability whose `resolution` targets a release outside this range is rendered under its pre-resolution state (`open` for `affected`, `dismissed` for `not affected` and `risk acceptable`), so the report reflects what is actually shipped at the chosen release.
 
 | `--tag <text>`
 | Filter on tags. Use multiple times to filter on multiple tags.
@@ -38,7 +39,9 @@ It contains the following sections:
 
 * *Header* — project organization, name, and author; the ISO-8601 UTC generation timestamp; the list of input file names (visible when several files are merged); and the applied filter (release, tags, reporter).
 * *Summary* — total entry count, breakdown by state, and breakdown of open entries by severity.
-* *Entry table* — four columns (IDs, State, Details, Releases) sorted by state (open first), then severity (critical to low), then primary ID. Each row carries a coloured left stripe: green for resolved, grey for dismissed, severity-coloured for open entries, and uncoloured for entries under investigation. The Details cell shows the verdict, severity (where applicable), the VEX justification for `not affected` entries, and the entry's description and analysis text.
+* *Entry table* — four columns (IDs, State, Details, Releases) sorted by state (open first), then severity (critical to low), then primary ID.
+Each row carries a coloured left stripe: green for resolved, grey for dismissed, severity-coloured for open entries, and uncoloured for entries under investigation.
+The Details cell shows the verdict, severity (where applicable), the VEX justification for `not affected` entries, and the entry's description and analysis text.
 * *Footer* — Vulnlog version and a link to vulnlog.dev.
 
 The report is fully offline (no network requests), CSP-locked, print-friendly, and adapts to the reader's light or dark system theme.

--- a/docs/modules/ROOT/pages/cli-suppress.adoc
+++ b/docs/modules/ROOT/pages/cli-suppress.adoc
@@ -20,6 +20,7 @@ vulnlog suppress <file> [flags]
 
 | `--release <text>`
 | Filter on release, include all releases up to and including that release.
+A vulnerability whose `resolution` targets a release outside this range is treated as still unresolved and a suppression entry is emitted, so scanners running against the deployed release stay quiet until the fix actually ships.
 
 | `--tag <text>`
 | Filter on tags. Use multiple times to filter on multiple tags.
@@ -43,6 +44,18 @@ Suppression file created at: /path/to/.trivyignore.yaml
 vulnlog suppress full-example.vl.yaml --release 8.1.1 --reporter snyk
 Suppression file created at: /path/to/.snyk
 ----
+
+.Suppress a not-yet-shipped fix when scanning the currently deployed release
+[source]
+----
+vulnlog suppress vulnlog.yaml --release 8.0.0 --reporter trivy
+----
+
+The CVE is fixed on the `dev` branch and the resolution targets the next, unpublished release.
+Until that release ships, the scanner running against the deployed `8.0.0` image keeps flagging the CVE.
+Generating the suppression file with `--release 8.0.0` includes the entry, so CI stays green.
+The vulnerability still appears as `open` in the HTML report under the same release.
+The pending-fix report needs an empty `suppress: { }` block on the relevant report so the entry is eligible for suppression.
 
 .Read from STDIN and write to STDOUT.
 [source]

--- a/docs/modules/ROOT/pages/vulnerability-states.adoc
+++ b/docs/modules/ROOT/pages/vulnerability-states.adoc
@@ -42,14 +42,12 @@ A `not affected` entry that later records a hygiene update moves from `dismissed
 
 == Perspective
 
-State describes the maintainer's view: has the triage team finished its work on this entry?
-It does not describe whether a currently running release contains the fix.
+By default, state describes the maintainer's view: has the triage team finished its work on this entry?
+It does not describe whether a currently running release contains the fix, so an entry can be `resolved` while the release carrying the fix is still unpublished.
 
-An entry can be `resolved` while the release carrying the fix is still unpublished.
-Release-scoped questions are answered by other means:
-
-* Use the `--release` filter on `vulnlog report` to list vulnerabilities present in a specific release.
-* See the `Fixed In` column (the entry's `resolution.in` field) for the release that contains the fix.
+When `--release X` is supplied to `vulnlog report` or `vulnlog suppress`, state shifts to a release-scoped view: a `resolution` only counts when its target release ships at-or-before `X`.
+A `resolution` pointing at a later or unpublished release is ignored for state classification, so the entry falls back to the state derived from its verdict (`open` for `affected`, `dismissed` for `not affected` and `risk acceptable`).
+The `Fixed In` column (the entry's `resolution.in` field) still shows the recorded fix release for reference.
 
 == Typical progression
 

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/ReportCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/ReportCommandTest.kt
@@ -201,4 +201,36 @@ class ReportCommandTest :
                 }
             }
         }
+
+        context("pending fix at deployed release") {
+
+            test("--release including only the deployed release renders an unshipped fix as open") {
+                withTempFile(content = vulnlogYamlWithPendingFix()) { input ->
+                    withTempFile(prefix = "report", suffix = ".html") { output ->
+                        val result =
+                            ReportCommand().test(
+                                "${input.absolutePath} --release 1.0.0 -o ${output.absolutePath}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        val html = output.readText()
+                        html shouldContain "CVE-2026-9999"
+                        html shouldContain "\"state\":\"open\""
+                    }
+                }
+            }
+
+            test("without --release the unshipped fix is rendered as resolved") {
+                withTempFile(content = vulnlogYamlWithPendingFix()) { input ->
+                    withTempFile(prefix = "report", suffix = ".html") { output ->
+                        val result = ReportCommand().test("${input.absolutePath} -o ${output.absolutePath}")
+
+                        result.statusCode shouldBe 0
+                        val html = output.readText()
+                        html shouldContain "CVE-2026-9999"
+                        html shouldContain "\"state\":\"resolved\""
+                    }
+                }
+            }
+        }
     })

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
@@ -170,4 +170,25 @@ class SuppressCommandTest :
                 result.stdout shouldContain "cargo-audit"
             }
         }
+
+        context("pending fix at deployed release") {
+
+            test("--release including only the deployed release suppresses an affected CVE whose fix is unshipped") {
+                withTempFile(content = vulnlogYamlWithPendingFix()) { input ->
+                    val result = SuppressCommand().test("${input.absolutePath} --release 1.0.0 -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldContain "CVE-2026-9999"
+                }
+            }
+
+            test("without --release the affected CVE with a resolution is dropped") {
+                withTempFile(content = vulnlogYamlWithPendingFix()) { input ->
+                    val result = SuppressCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldNotContain "CVE-2026-9999"
+                }
+            }
+        }
     })

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
@@ -49,6 +49,49 @@ internal fun vulnlogYaml(
     """.trimIndent()
 
 /**
+ * Builds a Vulnlog YAML document for the "pending fix" scenario: an `Affected` CVE present in a
+ * published release whose resolution targets a later release that has not been published yet
+ * (no `published_at`).
+ */
+internal fun vulnlogYamlWithPendingFix(
+    publishedRelease: String = "1.0.0",
+    publishedAt: String = "2026-01-15",
+    pendingRelease: String = "1.0.1",
+    cveId: String = "CVE-2026-9999",
+    reporter: String = "trivy",
+): String =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: $publishedRelease
+        published_at: $publishedAt
+      - id: $pendingRelease
+
+    vulnerabilities:
+
+      - id: $cveId
+        releases: [ $publishedRelease ]
+        description: Remote code execution in tomcat
+        packages: [ "pkg:maven/org.apache.tomcat/tomcat-core@10.1.0" ]
+        reports:
+          - reporter: $reporter
+            suppress: { }
+        analysis: Fix landed on dev but no release has been cut yet.
+        analyzed_at: $publishedAt
+        severity: high
+        verdict: affected
+        resolution:
+          in: $pendingRelease
+    """.trimIndent()
+
+/**
  * A YAML document missing required fields — used to exercise parse-failure paths.
  */
 internal val INVALID_VULNLOG_YAML: String =

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
@@ -3,6 +3,7 @@
 package dev.vulnlog.lib.core
 
 import dev.vulnlog.lib.model.Project
+import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.Verdict
 import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.model.VulnlogFile
@@ -38,7 +39,7 @@ fun collectReportingEntries(
         .applyFilter(filter)
         .map { vuln ->
             ReportingEntry(
-                state = findWorkState(vuln),
+                state = findWorkState(vuln, filter.releases),
                 primaryId = vuln.id,
                 ids = vuln.aliases.toSet(),
                 shortDescription = vuln.description,
@@ -82,13 +83,23 @@ private fun mergeTwo(
         fixedIn = a.fixedIn + b.fixedIn,
     )
 
-private fun findWorkState(vulnEntry: VulnerabilityEntry): WorkState =
-    when (vulnEntry.verdict) {
+private fun findWorkState(
+    vulnEntry: VulnerabilityEntry,
+    filterReleases: Set<Release>,
+): WorkState {
+    // Under --release X, a resolution counts only when its target release has shipped at-or-before X.
+    // Without a release context, every resolution counts (the historical default).
+    val resolution =
+        vulnEntry.resolution?.takeIf {
+            filterReleases.isEmpty() || it.release in filterReleases
+        }
+    return when (vulnEntry.verdict) {
         Verdict.UnderInvestigation -> WorkState.UNDER_INVESTIGATION
-        is Verdict.Affected -> if (vulnEntry.resolution != null) WorkState.RESOLVED else WorkState.OPEN
-        is Verdict.NotAffected -> if (vulnEntry.resolution != null) WorkState.RESOLVED else WorkState.DISMISSED
-        is Verdict.RiskAcceptable -> if (vulnEntry.resolution != null) WorkState.RESOLVED else WorkState.DISMISSED
+        is Verdict.Affected -> if (resolution != null) WorkState.RESOLVED else WorkState.OPEN
+        is Verdict.NotAffected -> if (resolution != null) WorkState.RESOLVED else WorkState.DISMISSED
+        is Verdict.RiskAcceptable -> if (resolution != null) WorkState.RESOLVED else WorkState.DISMISSED
     }
+}
 
 private fun defineImpact(vulnEntry: VulnerabilityEntry): Impact =
     when (vulnEntry.verdict) {

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
@@ -30,7 +30,7 @@ fun collectSuppressedVulnerabilities(
 ): Map<ReporterType, List<SuppressedVulnerability>> =
     vulnlogFile.vulnerabilities
         .asSequence()
-        .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today) }
+        .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today, filter.filter) }
         .applyFilter(filter)
         .groupBy { it.reporter }
         .filter { filter.filter.reporter == null || it.key == filter.filter.reporter }
@@ -38,9 +38,14 @@ fun collectSuppressedVulnerabilities(
 private fun explodeAndMapToSuppressedVulnerabilities(
     vulnerability: VulnerabilityEntry,
     today: LocalDate,
+    filter: VulnlogFilter,
 ): List<SuppressedVulnerability> {
     if (vulnerability.verdict is Verdict.Affected && vulnerability.resolution != null) {
-        return emptyList()
+        // When --release X is given, treat the resolution as effective only if it shipped at-or-before X.
+        // Without a release context, fall back to dropping unconditionally (the fix is the canonical answer).
+        val resolutionShipped =
+            filter.releases.isEmpty() || vulnerability.resolution.release in filter.releases
+        if (resolutionShipped) return emptyList()
     }
     return vulnerability.reports.flatMap { report ->
         if (!isReportEligible(vulnerability.verdict, report.suppress, today)) {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
@@ -223,6 +223,63 @@ class ReportingTest :
 
                 result.first().state shouldBe WorkState.RESOLVED
             }
+
+            test("Affected with resolution outside filter releases stays OPEN") {
+                val vuln =
+                    vulnerability(
+                        releases = listOf(releaseV1),
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file, VulnlogFilter(releases = setOf(releaseV1)))
+
+                result.first().state shouldBe WorkState.OPEN
+            }
+
+            test("Affected with resolution inside filter releases is RESOLVED") {
+                val vuln =
+                    vulnerability(
+                        releases = listOf(releaseV1, releaseV2),
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result =
+                    collectReportingEntries(file, VulnlogFilter(releases = setOf(releaseV1, releaseV2)))
+
+                result.first().state shouldBe WorkState.RESOLVED
+            }
+
+            test("NotAffected with resolution outside filter releases falls back to DISMISSED") {
+                val vuln =
+                    vulnerability(
+                        releases = listOf(releaseV1),
+                        verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file, VulnlogFilter(releases = setOf(releaseV1)))
+
+                result.first().state shouldBe WorkState.DISMISSED
+            }
+
+            test("RiskAcceptable with resolution outside filter releases falls back to DISMISSED") {
+                val vuln =
+                    vulnerability(
+                        releases = listOf(releaseV1),
+                        verdict = Verdict.RiskAcceptable(Severity.LOW),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = vulnlogFile(vulnerabilities = listOf(vuln))
+
+                val result = collectReportingEntries(file, VulnlogFilter(releases = setOf(releaseV1)))
+
+                result.first().state shouldBe WorkState.DISMISSED
+            }
         }
 
         context("mergeReportingEntries") {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionTest.kt
@@ -205,6 +205,37 @@ class SuppressionTest :
                 result.shouldBeEmpty()
             }
 
+            test("includes affected vulnerability whose resolution targets a release outside the filter") {
+                val vuln =
+                    vulnerability(
+                        releases = listOf(releaseV1),
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result[ReporterType.TRIVY]!! shouldHaveSize 1
+                result[ReporterType.TRIVY]!!.first().id shouldBe VulnId.Cve("CVE-2024-0001")
+            }
+
+            test("excludes affected vulnerability whose resolution shipped within the filter releases") {
+                val vuln =
+                    vulnerability(
+                        releases = listOf(releaseV1, releaseV2),
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1, releaseV2)), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result.shouldBeEmpty()
+            }
+
             test("includes affected vulnerability without resolution when suppress present") {
                 val vuln = vulnerability(verdict = Verdict.Affected(Severity.HIGH))
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))


### PR DESCRIPTION
Make HTML reports and suppression generation release-aware. 

When using the command `--release X`, a resolution is considered effective only if the target release ships before or at X. Resolutions targeting an unshipped or later release are treated as if no resolution existed.

The "suppress" command generates a suppression entry, and the "report" command displays the vulnerability in its pre-resolution state.

Without the `--release` flag, behavior remains unchanged, and any resolution is treated as effective. This unblocks CI pipelines that scan an older deployed release while a fix waits on "dev/main" for the next release.