### PR TITLE
feat: Switch suppress -o from directory to file path

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
             -u "$(id -u):$(id -g)" \
             -v "${{ github.workspace }}:/work" \
             ghcr.io/${{ github.repository }}:0.13.0 \
-            suppress vulnlog.yaml -o /work
+            suppress vulnlog.yaml --output-dir /work
 
       - name: Ensure suppression files exist
         run: |

--- a/devdoc/GitHub-Action-Pipelines.md
+++ b/devdoc/GitHub-Action-Pipelines.md
@@ -111,7 +111,7 @@ flowchart TD
 
 ### Job details
 
-- **suppress**: runs `ghcr.io/<repo>:latest suppress vulnlog.yaml -o /work` to produce `.snyk` and `.trivyignore.yaml`,
+- **suppress**: runs `ghcr.io/<repo>:latest suppress vulnlog.yaml --output-dir /work` to produce `.snyk` and `.trivyignore.yaml`,
   then uploads them as the `suppressions` artifact. `continue-on-error: true` so a missing image or empty Vulnlog config
   does not fail the whole run.
 - **snyk**: runs `snyk/actions/gradle@master` with `--policy-path=.snyk --all-sub-projects`; uploads results as SARIF

--- a/docs/modules/ROOT/pages/ci-integration.adoc
+++ b/docs/modules/ROOT/pages/ci-integration.adoc
@@ -30,7 +30,7 @@ jobs:
             -v "${{ github.workspace }}:/work" \
             -w /work \
             ghcr.io/vulnlog/vulnlog:{vulnlog-version} \
-            suppress --reporter trivy vulnlog.yaml -o /work
+            suppress --reporter trivy vulnlog.yaml --output-dir /work
 
       - name: Ensure suppression file exists
         run: |

--- a/docs/modules/ROOT/pages/cli-suppress.adoc
+++ b/docs/modules/ROOT/pages/cli-suppress.adoc
@@ -12,8 +12,14 @@ vulnlog suppress <file> [flags]
 |===
 | Flag | Description
 
-| `-o, --output <path>`
-| Output directory, or `-` to write to stdout. Defaults to current directory.
+| `-o, --output <file>`
+| Output file path, or `-` to write to stdout.
+Requires a single reporter (either set `--reporter`, or the input must apply to only one reporter).
+Mutually exclusive with `--output-dir`.
+
+| `--output-dir <dir>`
+| Output directory for the suppression files. Defaults to the current directory.
+Mutually exclusive with `-o, --output`.
 
 | `--reporter <value>`
 | Filter on reporter.
@@ -45,6 +51,13 @@ vulnlog suppress full-example.vl.yaml --release 8.1.1 --reporter snyk
 Suppression file created at: /path/to/.snyk
 ----
 
+.Write a single reporter's suppression file under a custom name
+[source]
+----
+vulnlog suppress full-example.vl.yaml --reporter trivy -o .myTrivy
+Suppression file created at: /path/to/.myTrivy
+----
+
 .Suppress a not-yet-shipped fix when scanning the currently deployed release
 [source]
 ----
@@ -63,8 +76,9 @@ The pending-fix report needs an empty `suppress: { }` block on the relevant repo
 vulnlog suppress --reporter trivy - -o - < full-example.vl.yaml > .myTrivy
 ----
 
-NOTE: Writing to stdout with `-o -` requires `--reporter` to select a single reporter.
-Multiple suppression files cannot be written to stdout simultaneously.
+NOTE: `-o` (including `-o -` for stdout) requires a single reporter.
+Set `--reporter` to pick one, or use an input that only applies to one reporter.
+To write all applicable suppression files in one go, use `--output-dir <dir>` instead.
 
 == Output Examples
 

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
@@ -70,16 +70,13 @@ fun OptionCallTransformContext.toOutputFileOption(output: String): FileOutputOpt
         FileOutputOption.File(outputPath)
     }
 
-fun OptionCallTransformContext.toOutputDirectoryOption(output: String): DirectoryOutputOption =
-    if (output == "-") {
-        DirectoryOutputOption.Stdout
-    } else {
-        val outputPath = Path.of(output)
-        if (!outputPath.isDirectory()) {
-            fail("Output path '$outputPath' is not a directory.")
-        }
-        DirectoryOutputOption.Directory(outputPath)
+fun OptionCallTransformContext.toOutputDirectoryOption(output: String): DirectoryOutputOption {
+    val outputPath = Path.of(output)
+    if (!outputPath.isDirectory()) {
+        fail("Output path '$outputPath' is not a directory.")
     }
+    return DirectoryOutputOption.Directory(outputPath)
+}
 
 fun ArgumentTransformContext.toInputFileOption(input: String): FileInputOption =
     if (input == "-") {
@@ -132,15 +129,14 @@ fun writeInit(
     }
 }
 
-fun writeSuppress(
+fun writeSuppressionFile(
     out: (String) -> Unit,
     err: (String) -> Unit,
-    outputDir: DirectoryOutputOption.Directory,
-    content: SuppressionFile,
+    outputPath: Path,
+    suppressionFile: SuppressionFile,
 ) {
-    val outputPath = outputDir.path.resolve(content.fileName)
     try {
-        outputPath.writeText(content.content)
+        outputPath.writeText(suppressionFile.content)
         out("Suppression file created at: ${outputPath.toAbsolutePath()}")
     } catch (e: Exception) {
         err("Error writing file: ${e.message}")

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/SuppressCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/SuppressCommand.kt
@@ -9,17 +9,23 @@ import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.ArgumentTransformContext
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.groups.default
+import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import com.github.ajalt.clikt.parameters.groups.single
+import com.github.ajalt.clikt.parameters.options.OptionCallTransformContext
 import com.github.ajalt.clikt.parameters.options.convert
-import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import dev.vulnlog.lib.core.SuppressionFilter
+import dev.vulnlog.lib.core.canonical
 import dev.vulnlog.lib.core.collectSuppressedVulnerabilities
 import dev.vulnlog.lib.core.mapToSuppression
 import dev.vulnlog.lib.parse.suppression.SuppressionFile
 import dev.vulnlog.lib.parse.suppression.SuppressionWriter.writeSuppressionOutput
 import dev.vulnlog.lib.shell.DirectoryOutputOption
 import dev.vulnlog.lib.shell.FileInputOption
+import dev.vulnlog.lib.shell.FileOutputOption
+import dev.vulnlog.lib.shell.OutputOption
 import java.nio.file.Path
 
 class SuppressCommand : CliktCommand(name = "suppress") {
@@ -29,11 +35,19 @@ class SuppressCommand : CliktCommand(name = "suppress") {
         help = "Vulnlog file, or '-' to read from stdin, to create suppression files from.",
     ).convert(conversion = ArgumentTransformContext::toInputFileOption)
 
-    val output: DirectoryOutputOption by option(
-        "-o",
-        "--output",
-        help = "Output directory, or '-' to write to stdout. Defaults to current directory.",
-    ).convert { toOutputDirectoryOption(it) }
+    val destination: OutputOption by mutuallyExclusiveOptions(
+        option(
+            "-o",
+            "--output",
+            help =
+                "Output file path, or '-' to write to stdout. " +
+                    "Requires a single reporter (set --reporter, or the input must apply to only one reporter).",
+        ).convert(conversion = OptionCallTransformContext::toOutputFileOption),
+        option(
+            "--output-dir",
+            help = "Output directory for the suppression files. Defaults to the current directory.",
+        ).convert(conversion = OptionCallTransformContext::toOutputDirectoryOption),
+    ).single()
         .default(DirectoryOutputOption.Directory(Path.of(System.getProperty("user.dir"))))
 
     val filterOptions by FilterOptions()
@@ -56,29 +70,54 @@ class SuppressCommand : CliktCommand(name = "suppress") {
         val suppressionVulns =
             collectSuppressedVulnerabilities(vulnlogFile, SuppressionFilter(filter))
         val outputSuppressions = mapToSuppression(targetReporters, suppressionVulns)
+        val contents: List<SuppressionFile> = outputSuppressions.map(::writeSuppressionOutput)
 
-        if (outputSuppressions.size > 1 && output is DirectoryOutputOption.Stdout) {
+        if (contents.isEmpty()) {
+            echo("No suppression entries applicable; nothing written.", err = true)
+            return
+        }
+
+        if (contents.size > 1 && destination !is DirectoryOutputOption) {
+            val names = targetReporters.map { it.canonical() }.sorted().joinToString(", ")
             echo(
-                "Error: Cannot write multiple suppression files to stdout. Use --reporter to select a single reporter.",
+                "Error: -o requires a single reporter. Use --reporter <name>, or the input must apply to only one reporter. Found: $names.",
                 err = true,
             )
             throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
         }
 
-        val contents: List<SuppressionFile> = outputSuppressions.map(::writeSuppressionOutput)
-
-        when (val target = output) {
-            is DirectoryOutputOption.Directory ->
-                contents.forEach { content ->
-                    writeSuppress(
-                        { echo(it) },
-                        { echo(it, err = true) },
-                        target,
-                        content,
-                    )
-                }
-
-            is DirectoryOutputOption.Stdout -> echo(contents.first().content)
+        when (val resolved = destination) {
+            is DirectoryOutputOption.Directory -> writeToDirectory(resolved, contents)
+            is FileOutputOption.File -> writeSingleFileOutput(resolved, contents.first())
+            FileOutputOption.Stdout -> echo(contents.first().content)
         }
+    }
+
+    private fun writeToDirectory(
+        destination: DirectoryOutputOption.Directory,
+        suppressionFiles: List<SuppressionFile>,
+    ) {
+        suppressionFiles.forEach { suppressionFile ->
+            val outputPath: Path = destination.path.resolve(suppressionFile.fileName)
+            writeSuppressionFile(
+                { echo(it) },
+                { echo(it, err = true) },
+                outputPath,
+                suppressionFile,
+            )
+        }
+    }
+
+    private fun writeSingleFileOutput(
+        destination: FileOutputOption.File,
+        suppressionFile: SuppressionFile,
+    ) {
+        val outputPath = destination.path
+        writeSuppressionFile(
+            { echo(it) },
+            { echo(it, err = true) },
+            outputPath,
+            suppressionFile,
+        )
     }
 }

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
@@ -6,6 +6,7 @@ package dev.vulnlog.cli.shell
 import com.github.ajalt.clikt.testing.test
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 
@@ -18,10 +19,24 @@ class SuppressCommandTest :
                 withTempFile(content = vulnlogYaml()) { input ->
                     withTempDir(prefix = "suppress-out") { outputDir ->
                         val result =
-                            SuppressCommand().test("${input.absolutePath} -o ${outputDir.toAbsolutePath()}")
+                            SuppressCommand().test("${input.absolutePath} --output-dir ${outputDir.toAbsolutePath()}")
 
                         result.statusCode shouldBe 0
                         result.stdout shouldContain "Suppression file created at:"
+                    }
+                }
+            }
+
+            test("-o writes the single applicable suppression file to the user-specified path") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    withTempDir(prefix = "suppress-out") { outputDir ->
+                        val target = outputDir.resolve("my-ignore.yaml")
+                        val result =
+                            SuppressCommand().test("${input.absolutePath} -o ${target.toAbsolutePath()}")
+
+                        result.statusCode shouldBe 0
+                        result.stdout shouldContain "Suppression file created at: ${target.toAbsolutePath()}"
+                        target.toFile().exists() shouldBe true
                     }
                 }
             }
@@ -47,10 +62,120 @@ class SuppressCommandTest :
             test("reads from stdin and writes to a directory") {
                 withTempDir(prefix = "suppress-out") { outputDir ->
                     withStdin(vulnlogYaml()) {
-                        val result = SuppressCommand().test("- -o ${outputDir.toAbsolutePath()}")
+                        val result = SuppressCommand().test("- --output-dir ${outputDir.toAbsolutePath()}")
 
                         result.statusCode shouldBe 0
                         result.stdout shouldContain "Suppression file created at:"
+                    }
+                }
+            }
+
+            test("falls back to the current working directory when no output flag is given") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    withTempDir(prefix = "suppress-cwd") { cwd ->
+                        val result = withCwd(cwd) { SuppressCommand().test(input.absolutePath) }
+
+                        result.statusCode shouldBe 0
+                        cwd.resolve(".trivyignore.yaml").toFile().exists() shouldBe true
+                    }
+                }
+            }
+
+            test("--output-dir writes one file per applicable reporter") {
+                withTempFile(content = vulnlogYamlMultiReporter()) { input ->
+                    withTempDir(prefix = "suppress-out") { outputDir ->
+                        val result =
+                            SuppressCommand().test("${input.absolutePath} --output-dir ${outputDir.toAbsolutePath()}")
+
+                        result.statusCode shouldBe 0
+                        outputDir.resolve(".trivyignore.yaml").toFile().exists() shouldBe true
+                        outputDir.resolve(".snyk").toFile().exists() shouldBe true
+                    }
+                }
+            }
+        }
+
+        context("single-file mode requires a single reporter") {
+
+            test("-o fails when multiple reporters apply and --reporter is not given") {
+                withTempFile(content = vulnlogYamlMultiReporter()) { input ->
+                    val result = SuppressCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe ExitCode.GENERAL_ERROR.ordinal
+                    result.stderr shouldContain "-o requires a single reporter"
+                    result.stderr shouldContain "snyk"
+                    result.stderr shouldContain "trivy"
+                }
+            }
+
+            test("-o with --reporter succeeds when multiple reporters apply") {
+                withTempFile(content = vulnlogYamlMultiReporter()) { input ->
+                    val result =
+                        SuppressCommand().test("${input.absolutePath} --reporter trivy -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldContain "CVE-2026-1234"
+                }
+            }
+
+            test("-o and --output-dir are mutually exclusive") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    withTempDir(prefix = "suppress-out") { outputDir ->
+                        val result =
+                            SuppressCommand().test(
+                                "${input.absolutePath} -o - --output-dir ${outputDir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldNotBe 0
+                        result.stderr shouldContain "cannot be used with"
+                    }
+                }
+            }
+
+            test("-o exits success with an informational message when nothing is suppressible") {
+                withTempFile(content = vulnlogYamlOtherReporterOnly()) { input ->
+                    val result = SuppressCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldContain "No suppression entries applicable"
+                    result.stdout shouldNotContain "CVE-2026-1234"
+                }
+            }
+
+            test("--output-dir exits success with an informational message when nothing is suppressible") {
+                withTempFile(content = vulnlogYamlOtherReporterOnly()) { input ->
+                    withTempDir(prefix = "suppress-out") { outputDir ->
+                        val result =
+                            SuppressCommand().test("${input.absolutePath} --output-dir ${outputDir.toAbsolutePath()}")
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain "No suppression entries applicable"
+                        val written = outputDir.toFile().listFiles().orEmpty()
+                        written.toList() shouldBe emptyList()
+                    }
+                }
+            }
+        }
+
+        context("output path validation") {
+
+            test("--output-dir fails when the path is not a directory") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    val result =
+                        SuppressCommand().test("${input.absolutePath} --output-dir /nonexistent/suppress-out")
+
+                    result.statusCode shouldNotBe 0
+                    result.stderr shouldContain "is not a directory"
+                }
+            }
+
+            test("-o fails when the path is a directory") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    withTempDir(prefix = "suppress-out") { outputDir ->
+                        val result = SuppressCommand().test("${input.absolutePath} -o ${outputDir.toAbsolutePath()}")
+
+                        result.statusCode shouldNotBe 0
+                        result.stderr shouldContain "is a directory, expected a file"
                     }
                 }
             }
@@ -112,7 +237,8 @@ class SuppressCommandTest :
                             withTempDir(prefix = "suppress-out") { outputDir ->
                                 val result =
                                     SuppressCommand().test(
-                                        "${input.absolutePath} --reporter $reporter -o ${outputDir.toAbsolutePath()}",
+                                        "${input.absolutePath} --reporter $reporter " +
+                                            "--output-dir ${outputDir.toAbsolutePath()}",
                                     )
 
                                 result.statusCode shouldBe 0

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
@@ -50,6 +50,38 @@ internal fun vulnlogYaml(
     """.trimIndent()
 
 /**
+ * Builds a Vulnlog YAML with reports from multiple reporters, so that suppress would emit more
+ * than one file unless filtered.
+ */
+internal fun vulnlogYamlMultiReporter(): String =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+          - reporter: snyk
+        analysis: not reachable
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+/**
  * Builds a Vulnlog YAML document for the "pending fix" scenario: an `Affected` CVE present in a
  * published release whose resolution targets a later release that has not been published yet
  * (no `published_at`).
@@ -90,6 +122,38 @@ internal fun vulnlogYamlWithPendingFix(
         verdict: affected
         resolution:
           in: $pendingRelease
+    """.trimIndent()
+
+/**
+ * Builds a Vulnlog YAML whose only report uses the `other` reporter, which is not suppressible
+ * — used to exercise the empty-output path of suppress.
+ */
+internal fun vulnlogYamlOtherReporterOnly(): String =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: other
+            source: in-house-scanner
+        analysis: not reachable
+        verdict: not affected
+        justification: vulnerable code not in execute path
     """.trimIndent()
 
 /**
@@ -137,6 +201,24 @@ internal inline fun <R> withTempDir(
         block(dir)
     } finally {
         dir.toFile().deleteRecursively()
+    }
+}
+
+/**
+ * Overrides the `user.dir` system property for the duration of [block]. The CLI commands read this
+ * to resolve their default output directory, so tests that exercise the default destination must
+ * set it to a temp path rather than polluting the real cwd.
+ */
+internal inline fun <R> withCwd(
+    cwd: Path,
+    block: () -> R,
+): R {
+    val original = System.getProperty("user.dir")
+    return try {
+        System.setProperty("user.dir", cwd.toAbsolutePath().toString())
+        block()
+    } finally {
+        System.setProperty("user.dir", original)
     }
 }
 

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/FileOutputOption.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/FileOutputOption.kt
@@ -5,7 +5,9 @@ package dev.vulnlog.lib.shell
 
 import java.nio.file.Path
 
-sealed interface FileOutputOption {
+sealed interface OutputOption
+
+sealed interface FileOutputOption : OutputOption {
     data object Stdout : FileOutputOption
 
     data class File(
@@ -13,9 +15,7 @@ sealed interface FileOutputOption {
     ) : FileOutputOption
 }
 
-sealed interface DirectoryOutputOption {
-    data object Stdout : DirectoryOutputOption
-
+sealed interface DirectoryOutputOption : OutputOption {
     data class Directory(
         val path: Path,
     ) : DirectoryOutputOption


### PR DESCRIPTION
This allows to specify the suppression file name explicitly and overwrite the default file name.

BREAKING CHANGE: The suppression command no longer accepts a directory path with the `-o`/`--output` flag; it now requires a file. Use the `--output-dir` flag to specify the directory.