### PR TITLE
refactor: Remove info level validation output in non-validate commands

### DIFF
--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
@@ -13,6 +13,7 @@ import dev.vulnlog.lib.parse.suppression.SuppressionFile
 import dev.vulnlog.lib.result.InputValidationResult
 import dev.vulnlog.lib.result.ParseResult
 import dev.vulnlog.lib.result.ParseResults
+import dev.vulnlog.lib.result.Severity
 import dev.vulnlog.lib.result.ValidationResults
 import dev.vulnlog.lib.shell.DirectoryOutputOption
 import dev.vulnlog.lib.shell.FileInputOption
@@ -48,8 +49,9 @@ fun CliktCommand.parseInputOrFail(inputs: List<FileInputOption>): Map<File, Pars
 
 fun CliktCommand.validateParsedInputOrFailWithFailureOutput(
     fileToResult: Map<File, ParseResult.Ok>,
+    renderedSeverities: Set<Severity> = setOf(Severity.ERROR),
 ): ValidationResults {
-    val validationFindings = validateFiles(fileToResult)
+    val validationFindings = validateFiles(fileToResult, renderedSeverities)
     if (validationFindings.renderedFindings.isNotBlank()) {
         echo(validationFindings.renderedFindings, err = true)
     }
@@ -58,6 +60,8 @@ fun CliktCommand.validateParsedInputOrFailWithFailureOutput(
     }
     return validationFindings
 }
+
+fun CliktCommand.printOutputSeparator() = echo("", err = true)
 
 fun OptionCallTransformContext.toOutputFileOption(output: String): FileOutputOption =
     if (output == "-") {

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
@@ -48,6 +48,7 @@ class CopyCommand : CliktCommand(name = "copy") {
         .unique()
 
     override fun run() {
+        printOutputSeparator()
         val parsedSource = parseInputOrFail(listOf(source))
         validateParsedInputOrFailWithFailureOutput(parsedSource)
         val sourceVulnlogFile = parsedSource.values.first().content

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/InitCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/InitCommand.kt
@@ -40,6 +40,7 @@ class InitCommand : CliktCommand(name = "init") {
     private val mapper = createYamlMapper()
 
     override fun run() {
+        printOutputSeparator()
         val vulnlogFile = init(CURRENT_VERSION, organization, project, author)
         val content = YamlWriter.write(vulnlogFile, mapper)
 

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ReportCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ReportCommand.kt
@@ -46,6 +46,7 @@ class ReportCommand : CliktCommand(name = "report") {
     val filterOptions by FilterOptions()
 
     override fun run() {
+        printOutputSeparator()
         val parsedSuccessfully = parseInputOrFail(inputs)
         validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
 

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/SuppressCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/SuppressCommand.kt
@@ -53,6 +53,7 @@ class SuppressCommand : CliktCommand(name = "suppress") {
     val filterOptions by FilterOptions()
 
     override fun run() {
+        printOutputSeparator()
         val parsedSuccessfully = parseInputOrFail(listOf(input))
         validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
 

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ValidateCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ValidateCommand.kt
@@ -12,6 +12,7 @@ import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import dev.vulnlog.lib.result.Severity
 import dev.vulnlog.lib.shell.FileInputOption
 
 class ValidateCommand : CliktCommand(name = "validate") {
@@ -24,8 +25,13 @@ class ValidateCommand : CliktCommand(name = "validate") {
     val strict: Boolean by option("--strict", help = "Treats warnings as errors.").flag(default = false)
 
     override fun run() {
+        printOutputSeparator()
         val parsedSuccessfully = parseInputOrFail(inputs)
-        val validationFindings = validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
+        val validationFindings =
+            validateParsedInputOrFailWithFailureOutput(
+                parsedSuccessfully,
+                renderedSeverities = Severity.entries.toSet(),
+            )
 
         if (validationFindings.hasWarnings && strict) {
             throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
 
 class SuppressCommandTest :
     FunSpec({
@@ -295,6 +296,28 @@ class SuppressCommandTest :
                 result.stdout shouldContain "github-advisory"
                 result.stdout shouldContain "npm-audit"
                 result.stdout shouldContain "cargo-audit"
+            }
+        }
+
+        context("uniform output formatting") {
+
+            test("prints a leading blank line on stderr to separate the output from the typed command") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    val result = SuppressCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldStartWith "\n"
+                }
+            }
+
+            test("does not print INFO-level validation findings") {
+                withTempFile(content = vulnlogYamlWithInfoFinding()) { input ->
+                    val result = SuppressCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldNotContain "Validation findings for"
+                    result.stderr shouldNotContain "[INFO ]"
+                }
             }
         }
 

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
@@ -157,6 +157,39 @@ internal fun vulnlogYamlOtherReporterOnly(): String =
     """.trimIndent()
 
 /**
+ * A Vulnlog YAML with a release that is not referenced by any vulnerability. Triggers a single
+ * INFO-severity validation finding (UNREFERENCED_RELEASE_ID) and no warnings or errors.
+ */
+internal fun vulnlogYamlWithInfoFinding(): String =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+      - id: 2.0.0
+        published_at: 2026-06-01
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        analysis: not reachable
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+/**
  * A YAML document missing required fields — used to exercise parse-failure paths.
  */
 internal val INVALID_VULNLOG_YAML: String =

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/ValidateCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/ValidateCommandTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.testing.test
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 
 class ValidateCommandTest :
     FunSpec({
@@ -44,6 +45,27 @@ class ValidateCommandTest :
                     val result = ValidateCommand().test("-")
 
                     result.statusCode shouldBe 0
+                    result.stdout shouldContain "Validation OK"
+                }
+            }
+
+            test("prints a leading blank line on stderr to separate the output from the typed command") {
+                withTempFile(content = vulnlogYaml()) { input ->
+                    val result = ValidateCommand().test(input.absolutePath)
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldStartWith "\n"
+                }
+            }
+
+            test("prints INFO-level findings for files with informational observations") {
+                withTempFile(content = vulnlogYamlWithInfoFinding()) { input ->
+                    val result = ValidateCommand().test(input.absolutePath)
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldContain "Validation findings for"
+                    result.stderr shouldContain "[INFO ]"
+                    result.stderr shouldContain "Unreferenced release ID"
                     result.stdout shouldContain "Validation OK"
                 }
             }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
@@ -6,6 +6,7 @@ package dev.vulnlog.gradle
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
+import dev.vulnlog.lib.result.Severity
 import dev.vulnlog.lib.shell.FileInputOption
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -32,7 +33,11 @@ abstract class VulnlogValidateTask : DefaultTask() {
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
         requireNonEmptyVulnlogFiles(inputFiles)
         val parsedSuccessfully = parseInputOrFail(inputFiles)
-        val validationFindings = validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
+        val validationFindings =
+            validateParsedInputOrFailWithFailureOutput(
+                parsedSuccessfully,
+                renderedSeverities = Severity.entries.toSet(),
+            )
         if (validationFindings.hasWarnings && strict.get()) {
             throw GradleException("Vulnlog validation failed.")
         }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleWrapper.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleWrapper.kt
@@ -7,6 +7,7 @@ import dev.vulnlog.lib.core.VulnlogFilter
 import dev.vulnlog.lib.model.VulnlogFile
 import dev.vulnlog.lib.result.ParseResult
 import dev.vulnlog.lib.result.ParseResults
+import dev.vulnlog.lib.result.Severity
 import dev.vulnlog.lib.result.ValidationResults
 import dev.vulnlog.lib.shell.FileInputOption
 import dev.vulnlog.lib.shell.FilterValidationException
@@ -61,8 +62,11 @@ fun buildFilterOrFail(
         throw GradleException("${e.message}. ${e.detail}")
     }
 
-fun DefaultTask.validateParsedInputOrFailWithFailureOutput(fileToResult: Map<File, ParseResult.Ok>): ValidationResults {
-    val validationFindings = validateFiles(fileToResult)
+fun DefaultTask.validateParsedInputOrFailWithFailureOutput(
+    fileToResult: Map<File, ParseResult.Ok>,
+    renderedSeverities: Set<Severity> = setOf(Severity.ERROR),
+): ValidationResults {
+    val validationFindings = validateFiles(fileToResult, renderedSeverities)
     if (validationFindings.renderedFindings.isNotBlank()) {
         logger.warn(validationFindings.renderedFindings)
     }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/ValidateFile.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/ValidateFile.kt
@@ -7,17 +7,25 @@ import dev.vulnlog.lib.core.renderValidation
 import dev.vulnlog.lib.core.validate
 import dev.vulnlog.lib.model.VulnlogFileContext
 import dev.vulnlog.lib.result.ParseResult
+import dev.vulnlog.lib.result.Severity
 import dev.vulnlog.lib.result.ValidationResult
 import dev.vulnlog.lib.result.ValidationResults
 import java.io.File
 
-fun validateFiles(fileToResult: Map<File, ParseResult.Ok>): ValidationResults {
+fun validateFiles(
+    fileToResult: Map<File, ParseResult.Ok>,
+    renderedSeverities: Set<Severity> = Severity.entries.toSet(),
+): ValidationResults {
     val contextToResults = validateEachFile(fileToResult)
     val renderedFindings =
         contextToResults
-            .filter { (_, findings) -> findings.findings.isNotEmpty() }
-            .map { (context, findings) -> context.fileName to renderValidation(findings) }
-            .joinToString("\n\n") { (filename, results) -> "Validation findings for $filename:\n$results" }
+            .map { (context, findings) ->
+                context.fileName to
+                    findings.copy(findings = findings.findings.filter { it.severity in renderedSeverities })
+            }.filter { (_, findings) -> findings.findings.isNotEmpty() }
+            .joinToString("\n\n") { (filename, findings) ->
+                "Validation findings for $filename:\n${renderValidation(findings)}"
+            }
     return ValidationResults(
         renderedFindings = renderedFindings,
         hasErrors = contextToResults.values.any { it.errors.isNotEmpty() },


### PR DESCRIPTION
This makes the output more readable because information and warning-level noise are no longer printed. Additionally, print a blank line after each command to clearly separate the output from the command.