### PR TITLE
ci: Remove auto-generated release notes and changelogs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,68 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  generate-changelog:
-    name: Generate changelog
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      release_notes_body: ${{ steps.release-notes.outputs.content || steps.release-notes-rc.outputs.content }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: main
-      - name: Prepend new changelog section
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: .github/changelog.toml
-          args: --unreleased --prepend CHANGELOG.md --tag ${{ github.ref_name }} --github-repo ${{ github.repository }}
-      - name: Open CHANGELOG.md pull request
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: peter-evans/create-pull-request@v7
-        with:
-          branch: chore/changelog-${{ github.ref_name }}
-          base: main
-          title: "docs(changelog): update for ${{ github.ref_name }}"
-          commit-message: "docs(changelog): update for ${{ github.ref_name }}"
-          body: |
-            Auto-generated changelog update for release `${{ github.ref_name }}`.
-
-            Before merging:
-            - Review the prepended section and fix any typos. `git-cliff` renders
-              squashed PR-title commit subjects verbatim, so PR-title typos surface
-              here.
-            - Add a compare-link entry at the top of the footer block, following the
-              existing convention (label without `v` prefix, URL tags with `v`):
-              `[<new-version>]: https://github.com/${{ github.repository }}/compare/<prev-tag>...${{ github.ref_name }}`.
-              `--prepend` does not regenerate the footer.
-
-            Merging is non-blocking for the rest of the release pipeline.
-          labels: |
-            changelog
-            automated
-          delete-branch: true
-      - name: Generate release notes
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: orhun/git-cliff-action@v4
-        id: release-notes
-        with:
-          config: .github/release-notes.toml
-          args: --latest --github-repo ${{ github.repository }}
-      - name: Release notes for RC
-        if: ${{ contains(github.ref_name, '-') }}
-        id: release-notes-rc
-        run: |
-          {
-            echo 'content<<EOF'
-            echo '🚧 Release candidate. Final release notes will be published with the final version.'
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
   build-native-images:
     name: Build native image (${{ matrix.artifact-name }})
     strategy:
@@ -92,7 +30,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [ generate-changelog, build-native-images ]
+    needs: [ build-native-images ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -133,9 +71,8 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: "Vulnlog ${{ github.ref_name }}"
           prerelease: true
+          generate_release_notes: true
           body: |
-            ${{needs.generate-changelog.outputs.release_notes_body}}
-
             👉 Full Changelog: https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md
           files: |
             modules/cli-app/build/distributions/*.zip
@@ -271,7 +208,6 @@ jobs:
 
   publish-gradle-plugin:
     name: Publish Gradle plugin
-    needs: [ generate-changelog ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      pull-requests: write
     outputs:
       release_notes_body: ${{ steps.release-notes.outputs.content || steps.release-notes-rc.outputs.content }}
     steps:
@@ -24,22 +25,37 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Generate a changelog
+          ref: main
+      - name: Prepend new changelog section
         uses: orhun/git-cliff-action@v4
         with:
           config: .github/changelog.toml
-          args: --tag ${{ github.ref_name }} --github-repo ${{ github.repository }}
-        env:
-          OUTPUT: CHANGELOG.md
-      - name: Commit CHANGELOG.md
+          args: --unreleased --prepend CHANGELOG.md --tag ${{ github.ref_name }} --github-repo ${{ github.repository }}
+      - name: Open CHANGELOG.md pull request
         if: ${{ !contains(github.ref_name, '-') }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "docs(changelog): update for ${{ github.ref_name }}" || echo "No changes to commit"
-          git pull --rebase origin main
-          git push origin HEAD:main
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/changelog-${{ github.ref_name }}
+          base: main
+          title: "docs(changelog): update for ${{ github.ref_name }}"
+          commit-message: "docs(changelog): update for ${{ github.ref_name }}"
+          body: |
+            Auto-generated changelog update for release `${{ github.ref_name }}`.
+
+            Before merging:
+            - Review the prepended section and fix any typos. `git-cliff` renders
+              squashed PR-title commit subjects verbatim, so PR-title typos surface
+              here.
+            - Add a compare-link entry at the top of the footer block, following the
+              existing convention (label without `v` prefix, URL tags with `v`):
+              `[<new-version>]: https://github.com/${{ github.repository }}/compare/<prev-tag>...${{ github.ref_name }}`.
+              `--prepend` does not regenerate the footer.
+
+            Merging is non-blocking for the rest of the release pipeline.
+          labels: |
+            changelog
+            automated
+          delete-branch: true
       - name: Generate release notes
         if: ${{ !contains(github.ref_name, '-') }}
         uses: orhun/git-cliff-action@v4

--- a/devdoc/GitHub-Action-Pipelines.md
+++ b/devdoc/GitHub-Action-Pipelines.md
@@ -76,8 +76,10 @@ level inside their jobs.
 
 ### Job details
 
-- **generate-changelog**: runs `git-cliff` twice: once to update `CHANGELOG.md` (committed to `main` only on final tags)
-  and once to produce the release-notes body for the GitHub release.
+- **generate-changelog**: runs `git-cliff` twice: once with `--unreleased --prepend` to add the new section to
+  `CHANGELOG.md` (opened as a PR against `main` on final tags via `peter-evans/create-pull-request`, skipped on RC tags)
+  and once to produce the release-notes body for the GitHub release. The PR is non-blocking — downstream release jobs
+  run in parallel and do not wait for it to merge.
 - **build-native-images**: matrix call of [`build-native.yaml`](../.github/workflows/build-native.yaml) for
   `ubuntu-latest`, `macos-latest`, and `windows-latest`. The tag (`github.ref_name`) is passed as `app-version`; the
   reusable workflow strips the leading `v` before invoking `-PappVersion=...`.
@@ -111,7 +113,8 @@ flowchart TD
 
 ### Job details
 
-- **suppress**: runs `ghcr.io/<repo>:latest suppress vulnlog.yaml --output-dir /work` to produce `.snyk` and `.trivyignore.yaml`,
+- **suppress**: runs `ghcr.io/<repo>:latest suppress vulnlog.yaml --output-dir /work` to produce `.snyk` and
+  `.trivyignore.yaml`,
   then uploads them as the `suppressions` artifact. `continue-on-error: true` so a missing image or empty Vulnlog config
   does not fail the whole run.
 - **snyk**: runs `snyk/actions/gradle@master` with `--policy-path=.snyk --all-sub-projects`; uploads results as SARIF

--- a/devdoc/GitHub-Action-Pipelines.md
+++ b/devdoc/GitHub-Action-Pipelines.md
@@ -56,19 +56,19 @@ flowchart TD
 ## CD
 
 Triggered by version tags. Release Candidate tags (e.g. `v0.12.0-rc1`) are detected via the `-` in the tag name; for
-those, the changelog commit, GitHub discussion, the `:latest` Docker tag, and the docs/website deploy are skipped, while
-native binaries, the (pre-)release, the versioned Docker tag, and the Gradle plugin publication still run.
+those, the GitHub discussion, the `:latest` Docker tag, and the docs/website deploy are skipped, while native binaries,
+the (pre-)release, the versioned Docker tag, and the Gradle plugin publication still run. The pipeline does not touch
+`CHANGELOG.md` and does not render the GitHub-release body — both are prepared manually by the maintainer (see
+[Releasing](Releasing.md)).
 
 ```mermaid
 flowchart TD
     TAG{{Tag vx.y.z or vx.y.z-rcN}}
-    TAG --> GC[generate-changelog<br/>git-cliff]
     TAG --> BNI[build-native-images<br/>matrix: linux / macos / windows]
-    GC --> PR2[publish-release<br/>GitHub release + discussion]
-    BNI --> PR2
+    BNI --> PR2[publish-release<br/>GitHub release + discussion]
     PR2 --> DP[deploy-pages<br/>Antora docs + website]
     BNI --> PDR[publish-docker<br/>ghcr.io :version + :latest]
-    GC --> PGP[publish-gradle-plugin<br/>plugins.gradle.org]
+    TAG --> PGP[publish-gradle-plugin<br/>plugins.gradle.org]
 ```
 
 Steps marked with dashed borders run only on final tags (no `-` in the tag name); other RC-aware gates apply at the step
@@ -76,16 +76,13 @@ level inside their jobs.
 
 ### Job details
 
-- **generate-changelog**: runs `git-cliff` twice: once with `--unreleased --prepend` to add the new section to
-  `CHANGELOG.md` (opened as a PR against `main` on final tags via `peter-evans/create-pull-request`, skipped on RC tags)
-  and once to produce the release-notes body for the GitHub release. The PR is non-blocking — downstream release jobs
-  run in parallel and do not wait for it to merge.
 - **build-native-images**: matrix call of [`build-native.yaml`](../.github/workflows/build-native.yaml) for
   `ubuntu-latest`, `macos-latest`, and `windows-latest`. The tag (`github.ref_name`) is passed as `app-version`; the
   reusable workflow strips the leading `v` before invoking `-PappVersion=...`.
 - **publish-release**: builds the JVM distribution zip, downloads and re-zips the three native binaries, and creates a
-  GitHub release marked `prerelease: true`. On final tags also opens an Announcement discussion via
-  `abirismyname/create-discussion` (pinned to v2.1.0 by SHA).
+  GitHub release marked `prerelease: true`. The body is GitHub's auto-generated "What's Changed" (`generate_release_notes: true`)
+  plus a link to `CHANGELOG.md`; the maintainer refines it in the UI before un-flagging the pre-release. On final tags
+  also opens an Announcement discussion via `abirismyname/create-discussion` (pinned to v2.1.0 by SHA).
 - **deploy-pages**: builds the Antora documentation, composes the static site, and deploys to GitHub Pages (
   `vulnlog.dev`). Skipped entirely on RC tags.
 - **publish-docker**: downloads the Linux native binary via the

--- a/devdoc/Releasing.md
+++ b/devdoc/Releasing.md
@@ -26,7 +26,7 @@ git push origin v0.12.0
 
 The pipeline will:
 
-1. Generate and commit an updated `CHANGELOG.md` to `main`
+1. Open a pull request against `main` with the new `CHANGELOG.md` section prepended
 2. Build native images for Linux, macOS, and Windows in parallel
 3. Build the JVM distribution zip
 4. Create a GitHub release (marked as pre-release) with all four artifacts attached
@@ -37,6 +37,49 @@ The pipeline will:
 
 Once you are satisfied with the release notes, publish the release manually from the GitHub UI
 to remove the pre-release flag.
+
+### Reviewing the changelog pull request
+
+Step 1 above opens a PR named `chore/changelog-v<version>` instead of pushing directly to `main`.
+This is a review gate, not a release blocker — the rest of the pipeline (builds, GitHub release,
+deploys) continues in parallel and does not wait for the PR to merge.
+
+`git-cliff` renders the squashed PR-title commit subject verbatim, so any typo in a PR title
+surfaces in the changelog (see [Pull Requests](Pull-Requests.md) for PR-title conventions).
+On the changelog PR:
+
+1. Skim the prepended `## [<version>]` section and fix any typos.
+2. Add a new compare-link entry at the top of the footer block, following the existing
+   convention (label without `v` prefix, URL tags with `v`):
+   `[<new-version>]: https://github.com/vulnlog/vulnlog/compare/<prev-tag>...v<new-version>`.
+   `git-cliff --prepend` only updates release sections; it does not regenerate the footer.
+3. Merge when it looks good.
+
+Only the new section is added on each release — prior sections are never regenerated, so any
+manual edits you make in the PR (or on `main` after the fact) are preserved across future
+releases.
+
+### Dry-run the changelog update locally
+
+To preview what the next release would prepend without pushing a tag, run `git-cliff` against
+a temporary copy of `CHANGELOG.md` and diff:
+
+```terminal
+cp CHANGELOG.md /tmp/CHANGELOG.preview.md
+git-cliff --config .github/changelog.toml --unreleased --tag v0.99.0-dryrun --github-repo vulnlog/vulnlog --prepend /tmp/CHANGELOG.preview.md
+diff -u CHANGELOG.md /tmp/CHANGELOG.preview.md
+rm /tmp/CHANGELOG.preview.md
+```
+
+or
+
+```terminal
+git-cliff --config .github/changelog.toml --unreleased --tag v0.99.0-dryrun --github-repo vulnlog/vulnlog --prepend CHANGELOG.md
+```
+
+The diff shows the new release section that the pipeline would prepend. The footer compare-link
+entry is intentionally not in the diff — that line is added manually in the changelog PR
+(see step 2 above).
 
 ## Release candidates
 
@@ -51,16 +94,16 @@ git push origin v0.12.0-rc1
 The CD pipeline detects RC tags via the `-` in the tag name and skips the steps that should
 only run for a final release:
 
-| Step                            | Final tag | RC tag    |
-|---------------------------------|-----------|-----------|
-| Native images (Linux/macOS/Win) | ✓         | ✓         |
-| GitHub release (pre-release)    | ✓         | ✓         |
-| Docker image `:<version>` tag   | ✓         | ✓         |
-| Gradle plugin publication       | ✓         | ✓         |
-| `CHANGELOG.md` commit to `main` | ✓         | *skipped* |
-| Docker image `:latest` tag      | ✓         | *skipped* |
-| Website and docs deploy         | ✓         | *skipped* |
-| GitHub Discussions announcement | ✓         | *skipped* |
+| Step                                    | Final tag | RC tag    |
+|-----------------------------------------|-----------|-----------|
+| Native images (Linux/macOS/Win)         | ✓         | ✓         |
+| GitHub release (pre-release)            | ✓         | ✓         |
+| Docker image `:<version>` tag           | ✓         | ✓         |
+| Gradle plugin publication               | ✓         | ✓         |
+| `CHANGELOG.md` PR opened against `main` | ✓         | *skipped* |
+| Docker image `:latest` tag              | ✓         | *skipped* |
+| Website and docs deploy                 | ✓         | *skipped* |
+| GitHub Discussions announcement         | ✓         | *skipped* |
 
 When the manual tests against the RC artifacts pass, tag the *same commit* with the final version
 and push it — the pipeline runs again and performs the steps that were skipped for the RC:

--- a/devdoc/Releasing.md
+++ b/devdoc/Releasing.md
@@ -13,73 +13,89 @@ The version is `SNAPSHOT+<git-short-hash>`, so it is always traceable to a speci
 
 ## Release builds (next CLI)
 
-Releases are automated via the [CD pipeline](../.github/workflows/cd.yaml).
-Tag a commit on `main` with the version (without the `v` prefix in the build, but with it in the tag),
-then push the tag. The pipeline triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+`
-(e.g. `v0.10.0`, `v0.11.2`, `v1.0.0`); maintenance tags `v0.9.*` are excluded and handled by
-[`cd-0.9.yaml`](../.github/workflows/cd-0.9.yaml).
+Releases are driven by version tags. The pipeline triggers on tags matching
+`v[0-9]+.[0-9]+.[0-9]+` (e.g. `v0.10.0`, `v0.11.2`, `v1.0.0`); maintenance tags `v0.9.*` are
+excluded and handled by [`cd-0.9.yaml`](../.github/workflows/cd-0.9.yaml). The pipeline builds
+and publishes artifacts only — it does not write `CHANGELOG.md` and does not generate the
+GitHub-release body. Both are prepared by the maintainer.
+
+### 1. Tag and push
+
+Tag a commit on `main` with the version (with the `v` prefix on the tag, without it in the
+build) and push:
 
 ```terminal
 git tag v0.12.0
 git push origin v0.12.0
 ```
 
-The pipeline will:
+The pipeline runs the following jobs, parallelised where dependencies allow:
 
-1. Open a pull request against `main` with the new `CHANGELOG.md` section prepended
-2. Build native images for Linux, macOS, and Windows in parallel
-3. Build the JVM distribution zip
-4. Create a GitHub release (marked as pre-release) with all four artifacts attached
-5. Publish the Gradle plugin to the Gradle Plugin Portal
-6. Push the Docker image to `ghcr.io` with both `:<version>` and `:latest` tags
-7. Deploy the website and Antora docs to GitHub Pages
-8. Post a release announcement in GitHub Discussions
+- **`build-native-images`** — Linux, macOS, and Windows native images in parallel
+- **`publish-gradle-plugin`** — publishes to the Gradle Plugin Portal (independent of the native build)
+- **`publish-release`** (after `build-native-images`) — builds the JVM distribution zip, creates a GitHub release
+  marked as pre-release with all four artifacts attached and a body containing GitHub's auto-generated "What's
+  Changed" list plus a link to `CHANGELOG.md`, and posts a release announcement in GitHub Discussions
+- **`publish-docker`** (after `build-native-images`) — pushes `ghcr.io` images with both `:<version>` and `:latest` tags
+- **`deploy-pages`** (after `publish-release`) — deploys the website and Antora docs to GitHub Pages
 
-Once you are satisfied with the release notes, publish the release manually from the GitHub UI
-to remove the pre-release flag.
+### 2. Fill in the GitHub-release body
 
-### Reviewing the changelog pull request
+The release lands as pre-release with the auto-generated GitHub "What's Changed" list (from PR
+titles) plus a link to `CHANGELOG.md`. Review it in the GitHub UI and refine as needed.
 
-Step 1 above opens a PR named `chore/changelog-v<version>` instead of pushing directly to `main`.
-This is a review gate, not a release blocker — the rest of the pipeline (builds, GitHub release,
-deploys) continues in parallel and does not wait for the PR to merge.
+To start from a richer draft based on conventional-commit grouping (`Features`, `Bug Fixes`, …),
+generate it locally with the release-notes config and paste it in:
 
-`git-cliff` renders the squashed PR-title commit subject verbatim, so any typo in a PR title
-surfaces in the changelog (see [Pull Requests](Pull-Requests.md) for PR-title conventions).
-On the changelog PR:
+```terminal
+git-cliff --config .github/release-notes.toml \
+  --latest --github-repo vulnlog/vulnlog \
+  --github-token "$(gh auth token)"
+```
 
-1. Skim the prepended `## [<version>]` section and fix any typos.
-2. Add a new compare-link entry at the top of the footer block, following the existing
-   convention (label without `v` prefix, URL tags with `v`):
-   `[<new-version>]: https://github.com/vulnlog/vulnlog/compare/<prev-tag>...v<new-version>`.
-   `git-cliff --prepend` only updates release sections; it does not regenerate the footer.
-3. Merge when it looks good.
+The `--github-token` keeps the call authenticated and avoids GitHub's unauthenticated API rate
+limit. Edit the body (fix PR-title typos, add highlights, link to docs) and save. Then un-flag
+the pre-release toggle to publish.
 
-Only the new section is added on each release — prior sections are never regenerated, so any
-manual edits you make in the PR (or on `main` after the fact) are preserved across future
-releases.
+### 3. Update `CHANGELOG.md`
 
-### Dry-run the changelog update locally
+On a branch off `main`, prepend the new release section with `git-cliff` and update the
+footer compare-link list:
 
-To preview what the next release would prepend without pushing a tag, run `git-cliff` against
-a temporary copy of `CHANGELOG.md` and diff:
+```terminal
+git checkout -b chore/changelog-v0.12.0 main
+git-cliff --config .github/changelog.toml \
+  --unreleased --tag v0.12.0 \
+  --github-repo vulnlog/vulnlog \
+  --prepend CHANGELOG.md
+```
+
+`git-cliff --prepend` rewrites `CHANGELOG.md` in place: it strips the existing `# Changelog`
+header, prepends the new `## [<version>]` section, and re-emits the header on top. It does
+**not** regenerate the footer compare-link block — add the new entry yourself at the top of
+that block, following the existing convention (label without `v` prefix, URL tags with `v`):
+
+```
+[<version>]: https://github.com/vulnlog/vulnlog/compare/<prev-tag>...v<version>
+```
+
+`git-cliff` renders the squashed PR-title commit subject verbatim, so any PR-title typo lands
+in the new section. Fix it here (see [Pull Requests](Pull-Requests.md) for the title
+conventions). Commit, open a PR against `main`, and merge it.
+
+This step can be done before tagging or after the release lands — the pipeline is independent.
+
+To preview the result before committing, prepend into a copy and diff:
 
 ```terminal
 cp CHANGELOG.md /tmp/CHANGELOG.preview.md
-git-cliff --config .github/changelog.toml --unreleased --tag v0.99.0-dryrun --github-repo vulnlog/vulnlog --prepend /tmp/CHANGELOG.preview.md
+git-cliff --config .github/changelog.toml \
+  --unreleased --tag v0.12.0 \
+  --github-repo vulnlog/vulnlog \
+  --prepend /tmp/CHANGELOG.preview.md
 diff -u CHANGELOG.md /tmp/CHANGELOG.preview.md
 rm /tmp/CHANGELOG.preview.md
 ```
-
-or
-
-```terminal
-git-cliff --config .github/changelog.toml --unreleased --tag v0.99.0-dryrun --github-repo vulnlog/vulnlog --prepend CHANGELOG.md
-```
-
-The diff shows the new release section that the pipeline would prepend. The footer compare-link
-entry is intentionally not in the diff — that line is added manually in the changelog PR
-(see step 2 above).
 
 ## Release candidates
 
@@ -94,16 +110,15 @@ git push origin v0.12.0-rc1
 The CD pipeline detects RC tags via the `-` in the tag name and skips the steps that should
 only run for a final release:
 
-| Step                                    | Final tag | RC tag    |
-|-----------------------------------------|-----------|-----------|
-| Native images (Linux/macOS/Win)         | ✓         | ✓         |
-| GitHub release (pre-release)            | ✓         | ✓         |
-| Docker image `:<version>` tag           | ✓         | ✓         |
-| Gradle plugin publication               | ✓         | ✓         |
-| `CHANGELOG.md` PR opened against `main` | ✓         | *skipped* |
-| Docker image `:latest` tag              | ✓         | *skipped* |
-| Website and docs deploy                 | ✓         | *skipped* |
-| GitHub Discussions announcement         | ✓         | *skipped* |
+| Step                            | Final tag | RC tag    |
+|---------------------------------|-----------|-----------|
+| Native images (Linux/macOS/Win) | ✓         | ✓         |
+| GitHub release (pre-release)    | ✓         | ✓         |
+| Docker image `:<version>` tag   | ✓         | ✓         |
+| Gradle plugin publication       | ✓         | ✓         |
+| Docker image `:latest` tag      | ✓         | *skipped* |
+| Website and docs deploy         | ✓         | *skipped* |
+| GitHub Discussions announcement | ✓         | *skipped* |
 
 When the manual tests against the RC artifacts pass, tag the *same commit* with the final version
 and push it — the pipeline runs again and performs the steps that were skipped for the RC:


### PR DESCRIPTION
The CI pipeline no longer automatically generates release notes or changelogs. This allows for more flexibility when writing them and fixing typos. The process is now semi-automatic; the maintainer generates and reviews the release notes first.

See also #135