### PR TITLE
feat: Add Homebrew installation support for Vulnlog CLI

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -92,6 +92,23 @@ jobs:
           category-name: Announcements
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  notify-homebrew:
+    name: Trigger Homebrew formula bump
+    needs: [ publish-release ]
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger homebrew formula bump
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_DISPATCH_TOKEN }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          gh api repos/vulnlog/homebrew-vulnlog/dispatches \
+            -f event_type=vulnlog-release \
+            -f client_payload[version]="$VERSION"
+
   deploy-pages:
     name: Deploy website and docs to GitHub Pages
     needs: [ publish-release ]

--- a/devdoc/GitHub-Action-Pipelines.md
+++ b/devdoc/GitHub-Action-Pipelines.md
@@ -67,6 +67,7 @@ flowchart TD
     TAG --> BNI[build-native-images<br/>matrix: linux / macos / windows]
     BNI --> PR2[publish-release<br/>GitHub release + discussion]
     PR2 --> DP[deploy-pages<br/>Antora docs + website]
+    PR2 --> NHB[notify-homebrew<br/>dispatch tap formula bump]
     BNI --> PDR[publish-docker<br/>ghcr.io :version + :latest]
     TAG --> PGP[publish-gradle-plugin<br/>plugins.gradle.org]
 ```
@@ -85,6 +86,11 @@ level inside their jobs.
   also opens an Announcement discussion via `abirismyname/create-discussion` (pinned to v2.1.0 by SHA).
 - **deploy-pages**: builds the Antora documentation, composes the static site, and deploys to GitHub Pages (
   `vulnlog.dev`). Skipped entirely on RC tags.
+- **notify-homebrew**: after the release assets are public, calls `POST /repos/vulnlog/homebrew-vulnlog/dispatches`
+  with `event_type=vulnlog-release` and `client_payload[version]=<tag without v>` (authenticated via the
+  `HOMEBREW_DISPATCH_TOKEN` secret). The tap's `bump-formula.yml` then recomputes the SHA256s, patches `vulnlog.rb`,
+  and opens a bump PR. Depends on `publish-release` so the zip URLs are live before the tap fetches them; skipped
+  entirely on RC tags.
 - **publish-docker**: downloads the Linux native binary via the
   [`fetch-native-binary`](../.github/actions/fetch-native-binary/action.yml) composite action and pushes
   `ghcr.io/<repo>:<tag>`; the floating `:latest` tag is added only on final releases.

--- a/devdoc/Releasing.md
+++ b/devdoc/Releasing.md
@@ -38,6 +38,9 @@ The pipeline runs the following jobs, parallelised where dependencies allow:
   Changed" list plus a link to `CHANGELOG.md`, and posts a release announcement in GitHub Discussions
 - **`publish-docker`** (after `build-native-images`) — pushes `ghcr.io` images with both `:<version>` and `:latest` tags
 - **`deploy-pages`** (after `publish-release`) — deploys the website and Antora docs to GitHub Pages
+- **`notify-homebrew`** (after `publish-release`) — dispatches a `vulnlog-release` event to
+  [`vulnlog/homebrew-vulnlog`](https://github.com/vulnlog/homebrew-vulnlog) so the tap bumps its formula and opens a
+  PR; runs only on final tags
 
 ### 2. Fill in the GitHub-release body
 
@@ -104,6 +107,7 @@ only run for a final release:
 | Docker image `:latest` tag      | ✓         | *skipped* |
 | Website and docs deploy         | ✓         | *skipped* |
 | GitHub Discussions announcement | ✓         | *skipped* |
+| Homebrew formula bump dispatch  | ✓         | *skipped* |
 
 When the manual tests against the RC artifacts pass, tag the *same commit* with the final version
 and push it — the pipeline runs again and performs the steps that were skipped for the RC:

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -87,6 +87,32 @@ curl -fsSL vulnlog.dev/uninstall | sh
 A versioned copy of the same script is also attached to each GitHub release as
 `install-vulnlog.sh` and `uninstall-vulnlog.sh`.
 
+== Homebrew (macOS)
+
+On macOS, install Vulnlog from the https://github.com/vulnlog/homebrew-vulnlog[Vulnlog tap].
+On Apple Silicon (`arm64`) the formula installs the native binary.
+On Intel (`x86_64`) there is no native build, so it installs the JVM distribution and pulls in `openjdk@21`
+as a dependency automatically.
+
+.Install in one step.
+[source,bash]
+----
+brew install vulnlog/vulnlog/vulnlog
+----
+
+.Or tap once, then install and upgrade with the bare name.
+[source,bash]
+----
+brew tap vulnlog/vulnlog
+brew install vulnlog
+----
+
+.Upgrade to the latest release.
+[source,bash]
+----
+brew update && brew upgrade vulnlog
+----
+
 == Native Binary
 
 Standalone native binaries are built with GraalVM and require no Java runtime.
@@ -123,7 +149,6 @@ The resulting distribution is placed in `build/install/vulnlog`.
 
 // Other ideas:
 // - Snap package (Linux)
-// - Homebrew formula (macOS / Linux)
 // - Scoop or Winget (Windows)
 // - APT / RPM repositories
 // - Nix package

--- a/website/index.html
+++ b/website/index.html
@@ -269,6 +269,13 @@
                     </script>
                 </div>
                 <div class="install-option">
+                    <h3>Homebrew (macOS)</h3>
+                    <div class="code-block" id="install-brew"></div>
+                    <script id="install-brew-src" type="text/plain">
+                        brew install vulnlog/vulnlog/vulnlog
+                    </script>
+                </div>
+                <div class="install-option">
                     <h3>Docker</h3>
                     <div class="code-block" id="install-docker"></div>
                     <script id="install-docker-src" type="text/plain">
@@ -488,6 +495,7 @@
     renderExample('hero-example', 'hero-example-src', highlightYaml);
     renderExample('cli-example', 'cli-example-src', highlightCli);
     renderExample('install-script', 'install-script-src', highlightPlain);
+    renderExample('install-brew', 'install-brew-src', highlightPlain);
     renderExample('install-docker', 'install-docker-src', highlightPlain);
     renderExample('install-gradle', 'install-gradle-src', highlightPlain);
 </script>


### PR DESCRIPTION
- trigger automation for formula updates
- Update website and documentation with Homebrew installation instructions
- Add GitHub Action to notify Homebrew tap for formula bump