### PR TITLE
feat: Add missing Jackson annotations in DTOs for non-null values

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/ReleaseEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/ReleaseEntryDto.kt
@@ -4,6 +4,7 @@
 package dev.vulnlog.lib.parse.v1.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
@@ -11,6 +12,8 @@ data class ReleaseEntryDto(
     val id: String,
     @param:JsonProperty("published_at")
     @param:JsonFormat(pattern = "yyyy-MM-dd")
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val publishedAt: LocalDate? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val purls: List<ReleasePurlEntryDto>? = null,
 )

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/ReportEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/ReportEntryDto.kt
@@ -11,6 +11,7 @@ import java.time.LocalDate
 data class ReportEntryDto(
     val reporter: String,
     @param:JsonFormat(pattern = "yyyy-MM-dd")
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val at: LocalDate? = null,
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val source: String? = null,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/SuppressionDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/SuppressionDto.kt
@@ -4,11 +4,13 @@
 package dev.vulnlog.lib.parse.v1.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
 data class SuppressionDto(
     @param:JsonProperty("expires_at")
     @param:JsonFormat(pattern = "yyyy-MM-dd")
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val expiresAt: LocalDate? = null,
 )

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/VulnerabilityEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/dto/VulnerabilityEntryDto.kt
@@ -12,10 +12,10 @@ data class VulnerabilityEntryDto(
     val id: String,
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val name: String? = null,
-    @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
-    val aliases: List<String> = emptyList(),
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val description: String? = null,
+    @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val aliases: List<String> = emptyList(),
     val releases: List<String>,
     val packages: List<String>,
     val reports: List<ReportEntryDto>,


### PR DESCRIPTION
This is a preparation for the following format command.