### PR TITLE
refactor: rename github-advisory reporter to github-dependabot

### DIFF
--- a/docs/modules/ROOT/pages/suppression.adoc
+++ b/docs/modules/ROOT/pages/suppression.adoc
@@ -160,8 +160,8 @@ The CLI determines which identifiers to write into the suppression file using th
 | --
 | No
 
-| `github-advisory`
-| GitHub Advisory Database
+| `github-dependabot`
+| GitHub Dependabot
 | --
 | No
 

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/SuppressCommandTest.kt
@@ -226,7 +226,7 @@ class SuppressCommandTest :
                     "trivy",
                     "snyk",
                     "dependency-check",
-                    "github-advisory",
+                    "github-dependabot",
                     "grype",
                     "npm-audit",
                     "cargo-audit",
@@ -293,7 +293,7 @@ class SuppressCommandTest :
                 val result = SuppressCommand().test("--help")
 
                 result.stdout shouldContain "dependency-check"
-                result.stdout shouldContain "github-advisory"
+                result.stdout shouldContain "github-dependabot"
                 result.stdout shouldContain "npm-audit"
                 result.stdout shouldContain "cargo-audit"
             }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reports.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reports.kt
@@ -9,7 +9,7 @@ import dev.vulnlog.lib.model.ReporterType
  * Parses a reporter string and returns the corresponding ReporterType enumeration value.
  *
  * @param reporter The string identifier of the reporter, expected to match one of the predefined reporter names.
- *                 Supported values include: "dependency-check", "github-advisory", "grype", "npm-audit",
+ *                 Supported values include: "dependency-check", "github-dependabot", "grype", "npm-audit",
  *                 "other", "cargo-audit", "semgrep", "snyk", and "trivy".
  * @return The corresponding ReporterType enumeration value for the specified reporter.
  * @throws IllegalArgumentException If the specified reporter is not supported.
@@ -17,7 +17,7 @@ import dev.vulnlog.lib.model.ReporterType
 fun parseReporter(reporter: String): ReporterType =
     when (reporter) {
         "dependency-check" -> ReporterType.DEPENDENCY_CHECK
-        "github-advisory" -> ReporterType.GITHUB_SECURITY_ADVISORY
+        "github-dependabot" -> ReporterType.GITHUB_DEPENDABOT
         "grype" -> ReporterType.GRYPE
         "npm-audit" -> ReporterType.NPM_AUDIT
         "other" -> ReporterType.OTHER
@@ -37,7 +37,7 @@ fun parseReporter(reporter: String): ReporterType =
 fun ReporterType.canonical(): String =
     when (this) {
         ReporterType.DEPENDENCY_CHECK -> "dependency-check"
-        ReporterType.GITHUB_SECURITY_ADVISORY -> "github-advisory"
+        ReporterType.GITHUB_DEPENDABOT -> "github-dependabot"
         ReporterType.GRYPE -> "grype"
         ReporterType.NPM_AUDIT -> "npm-audit"
         ReporterType.OTHER -> "other"

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
@@ -104,7 +104,7 @@ fun mapToSuppression(
 private fun getDefaultSettingsForReporter(reporter: ReporterType): Suppression =
     when (reporter) {
         ReporterType.DEPENDENCY_CHECK -> Suppressable.GenericFormat.Generic(reporter)
-        ReporterType.GITHUB_SECURITY_ADVISORY -> Suppressable.GenericFormat.Generic(reporter)
+        ReporterType.GITHUB_DEPENDABOT -> Suppressable.GenericFormat.Generic(reporter)
         ReporterType.GRYPE -> Suppressable.GenericFormat.Generic(reporter)
         ReporterType.NPM_AUDIT -> Suppressable.GenericFormat.Generic(reporter)
         ReporterType.OTHER -> NotSuppressable

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/ReportEntry.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/ReportEntry.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 enum class ReporterType {
     DEPENDENCY_CHECK,
-    GITHUB_SECURITY_ADVISORY,
+    GITHUB_DEPENDABOT,
     GRYPE,
     NPM_AUDIT,
     OTHER,

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportsTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportsTest.kt
@@ -16,8 +16,8 @@ class ReportsTest :
                 parseReporter("dependency-check") shouldBe ReporterType.DEPENDENCY_CHECK
             }
 
-            test("parses github-advisory") {
-                parseReporter("github-advisory") shouldBe ReporterType.GITHUB_SECURITY_ADVISORY
+            test("parses github-dependabot") {
+                parseReporter("github-dependabot") shouldBe ReporterType.GITHUB_DEPENDABOT
             }
 
             test("parses grype") {
@@ -60,8 +60,8 @@ class ReportsTest :
                 ReporterType.DEPENDENCY_CHECK.canonical() shouldBe "dependency-check"
             }
 
-            test("GITHUB_SECURITY_ADVISORY canonical is github-advisory") {
-                ReporterType.GITHUB_SECURITY_ADVISORY.canonical() shouldBe "github-advisory"
+            test("GITHUB_DEPENDABOT canonical is github-dependabot") {
+                ReporterType.GITHUB_DEPENDABOT.canonical() shouldBe "github-dependabot"
             }
 
             test("GRYPE canonical is grype") {
@@ -96,7 +96,7 @@ class ReportsTest :
                 val allCanonicals =
                     listOf(
                         "dependency-check",
-                        "github-advisory",
+                        "github-dependabot",
                         "grype",
                         "npm-audit",
                         "other",

--- a/perf/perf.vl.yaml
+++ b/perf/perf.vl.yaml
@@ -94,7 +94,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-02-22
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-26
         suppress: {}
     tags:
@@ -365,7 +365,7 @@ vulnerabilities:
       - reporter: cargo-audit
         at: 2024-04-03
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-01
         vuln_ids: [GHSA-perf00982-extra-1]
     tags: [transitive]
@@ -460,7 +460,7 @@ vulnerabilities:
       - 1.0.2
     packages: ["pkg:maven/io.netty/netty-codec-http@5.2.37"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
       - reporter: npm-audit
         at: 2024-02-01
@@ -636,7 +636,7 @@ vulnerabilities:
       - 1.1.1
     packages: ["pkg:docker/library/nginx@8.8.19"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-21
       - reporter: npm-audit
         at: 2024-03-18
@@ -655,7 +655,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:maven/org.apache.httpcomponents/httpclient@1.23.19"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-01
       - reporter: npm-audit
         at: 2024-02-25
@@ -677,7 +677,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-02-12
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-15
         vuln_ids: [GHSA-perf00965-extra-1]
       - reporter: npm-audit
@@ -700,7 +700,7 @@ vulnerabilities:
       - 1.1.0
     packages: ["pkg:docker/library/postgres@8.2.30"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-25
         vuln_ids: [GHSA-perf00964-extra-0]
       - reporter: trivy
@@ -764,7 +764,7 @@ vulnerabilities:
       - 1.0.6
     packages: ["pkg:maven/org.bouncycastle/bcpkix-jdk18on@6.1.38"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-17
         vuln_ids: [GHSA-perf00960-extra-0]
     tags: [container]
@@ -905,7 +905,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-02-05
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-03
         vuln_ids: [GHSA-perf00953-extra-1]
       - reporter: cargo-audit
@@ -923,7 +923,7 @@ vulnerabilities:
     releases: [1.0.2]
     packages: ["pkg:cargo/serde_json@9.3.3"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-24
         vuln_ids: [GHSA-perf00952-extra-0]
         suppress: {}
@@ -1009,7 +1009,7 @@ vulnerabilities:
       - 1.0.4
     packages: ["pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@2.19.2"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-15
       - reporter: cargo-audit
         at: 2024-02-14
@@ -1147,7 +1147,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:docker/library/postgres@2.25.0"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-03
 
   - id: GHSA-perf00939-bbbb-3682
@@ -1294,7 +1294,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:maven/org.springframework.security/spring-security-core@10.28.20"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-22
         vuln_ids: [GHSA-perf00932-extra-0]
       - reporter: npm-audit
@@ -1306,7 +1306,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:maven/org.apache.kafka/kafka-clients@3.1.39.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-27
         vuln_ids: [GHSA-perf00931-extra-0]
     analysis: Network access to the affected endpoint is restricted by the perimeter firewall.
@@ -1337,7 +1337,7 @@ vulnerabilities:
       - "pkg:maven/io.netty/netty-codec-http@13.30.38"
       - "pkg:maven/mysql/mysql-connector-java@13.30.38"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-04
     tags: [transitive]
     analysis: Network access to the affected endpoint is restricted by the perimeter firewall.
@@ -1371,7 +1371,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-02-17
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-16
         vuln_ids: [GHSA-perf00927-extra-1]
     analysis: The vulnerable parser is not reachable in our configuration.
@@ -1444,7 +1444,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-02-28
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-02
         vuln_ids: [GHSA-perf00923-extra-1]
 
@@ -1566,7 +1566,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:maven/org.yaml/snakeyaml@1.11.39"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-08
     tags: [test-infra]
 
@@ -1597,7 +1597,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-02-22
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-22
     tags: [frontend]
     analysis: >-
@@ -1677,7 +1677,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:npm/follow-redirects@0.16.0"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-27
       - reporter: grype
         at: 2024-02-25
@@ -1771,7 +1771,7 @@ vulnerabilities:
       - "pkg:docker/library/nginx@6.1.37"
       - "pkg:npm/follow-redirects@6.1.37"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-25
         suppress: {}
       - reporter: semgrep
@@ -1841,7 +1841,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-01-21
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-19
       - reporter: snyk
         at: 2024-01-22
@@ -2056,7 +2056,7 @@ vulnerabilities:
       - 1.0.5
     packages: ["pkg:npm/tough-cookie@6.21.37"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-02
     analysis: This dependency is loaded only by the build pipeline and never reaches production.
     analyzed_at: 2024-03-08
@@ -2104,7 +2104,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-02-03
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
         vuln_ids: [GHSA-perf00885-extra-1]
     tags: [binary]
@@ -2125,7 +2125,7 @@ vulnerabilities:
       - 1.1.0
     packages: ["pkg:npm/express@9.17.22"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-14
         vuln_ids: [GHSA-perf00884-extra-0]
       - reporter: dependency-check
@@ -2175,7 +2175,7 @@ vulnerabilities:
         vuln_ids: [SNYK-JAVA-PERF-700882-1]
         suppress:
           expires_at: 2024-04-08
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-16
         suppress:
           expires_at: 2024-05-19
@@ -2227,7 +2227,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:maven/org.apache.httpcomponents/httpclient@5.24.34"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-03
         vuln_ids: [GHSA-perf00879-extra-0]
     tags:
@@ -2324,7 +2324,7 @@ vulnerabilities:
       - reporter: snyk
         at: 2024-02-16
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-14
     tags:
       - backend
@@ -2842,7 +2842,7 @@ vulnerabilities:
       - "pkg:maven/org.apache.commons/commons-text@3.24.3"
       - "pkg:maven/io.micrometer/micrometer-core@3.24.3"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-23
         vuln_ids: [GHSA-perf00846-extra-0]
     analysis: "Risk accepted: the impacted code path is gated behind CI-only authentication."
@@ -2906,7 +2906,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:maven/org.apache.logging.log4j/log4j-core@5.25.9.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-28
         vuln_ids: [GHSA-perf00842-extra-0]
         suppress:
@@ -2960,7 +2960,7 @@ vulnerabilities:
     releases: [1.1.1]
     packages: ["pkg:pypi/aiohttp@6.7.13"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-31
         vuln_ids: [GHSA-perf00839-extra-0]
       - reporter: npm-audit
@@ -3026,7 +3026,7 @@ vulnerabilities:
         at: 2024-04-04
       - reporter: npm-audit
         at: 2024-04-03
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-04
         vuln_ids: [GHSA-perf00836-extra-2]
     tags: [test-infra]
@@ -3115,7 +3115,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-02-20
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-23
     tags: [binary]
     analysis: Affected configuration option is hard-coded to a safe value in our build.
@@ -3172,7 +3172,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-02-07
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-07
       - reporter: cargo-audit
         at: 2024-02-11
@@ -3254,7 +3254,7 @@ vulnerabilities:
     releases: [1.0.7]
     packages: ["pkg:npm/%40babel/traverse@0.7.2"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-10
         vuln_ids: [GHSA-perf00823-extra-0]
       - reporter: cargo-audit
@@ -3319,7 +3319,7 @@ vulnerabilities:
       - reporter: snyk
         at: 2024-04-14
         vuln_ids: [SNYK-JAVA-PERF-700820-1]
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-16
         vuln_ids: [GHSA-perf00820-extra-2]
     tags: [backend]
@@ -3365,7 +3365,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-02-11
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-08
     tags: [build-dep]
 
@@ -3545,7 +3545,7 @@ vulnerabilities:
       - "pkg:maven/org.apache.commons/commons-lang3@2.25.14"
       - "pkg:maven/org.apache.logging.log4j/log4j-core@2.25.14"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
         vuln_ids: [GHSA-perf00806-extra-0]
     analysis: >-
@@ -3562,7 +3562,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-02-06
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
         vuln_ids: [GHSA-perf00805-extra-1]
       - reporter: snyk
@@ -3596,7 +3596,7 @@ vulnerabilities:
     releases: [1.1.0]
     packages: ["pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@14.4.4"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-23
     analysis: The vulnerable code path requires anonymous write access, which our application does not satisfy.
     analyzed_at: 2024-04-25
@@ -3658,7 +3658,7 @@ vulnerabilities:
     releases: [1.1.0]
     packages: ["pkg:maven/org.springframework/spring-webmvc@12.7.28-SNAPSHOT"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-12
         vuln_ids: [GHSA-perf00800-extra-0]
       - reporter: semgrep
@@ -3700,7 +3700,7 @@ vulnerabilities:
     reports:
       - reporter: snyk
         at: 2024-01-18
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-19
         vuln_ids: [GHSA-perf00798-extra-1]
     analysis: "Risk accepted: the impacted code path is gated behind internal admin-only authentication."
@@ -3756,7 +3756,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:maven/org.slf4j/slf4j-api@9.16.17.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-22
         vuln_ids: [GHSA-perf00795-extra-0]
       - reporter: trivy
@@ -3886,7 +3886,7 @@ vulnerabilities:
       - reporter: trivy
         at: 2024-04-04
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-02
         vuln_ids: [GHSA-perf00789-extra-2]
         suppress: {}
@@ -3942,7 +3942,7 @@ vulnerabilities:
       - "pkg:maven/io.jsonwebtoken/jjwt-impl@12.15.14"
       - "pkg:maven/commons-fileupload/commons-fileupload@12.15.14"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-17
         vuln_ids: [GHSA-perf00786-extra-0]
         suppress: {}
@@ -3989,7 +3989,7 @@ vulnerabilities:
       - "pkg:npm/axios@11.11.21"
       - "pkg:maven/tools.jackson.core/jackson-core@11.11.21"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-29
         vuln_ids: [GHSA-perf00784-extra-0]
         suppress:
@@ -4173,7 +4173,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:pypi/requests@9.19.6"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
         vuln_ids: [GHSA-perf00774-extra-0]
     tags: [container]
@@ -4329,7 +4329,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:maven/com.squareup.okhttp3/okhttp@1.21.38"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-06
         vuln_ids: [GHSA-perf00766-extra-0]
       - reporter: npm-audit
@@ -4351,7 +4351,7 @@ vulnerabilities:
       - "pkg:pypi/numpy@5.1.32"
       - "pkg:npm/express@5.1.32"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-15
     tags:
       - ci-only
@@ -4372,7 +4372,7 @@ vulnerabilities:
     releases: [1.0.7]
     packages: ["pkg:npm/postcss@1.15.17"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-30
     tags:
       - transitive
@@ -4394,7 +4394,7 @@ vulnerabilities:
         at: 2024-02-13
       - reporter: cargo-audit
         at: 2024-02-15
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-11
         vuln_ids: [GHSA-perf00763-extra-2]
     tags: [container]
@@ -4554,7 +4554,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:maven/org.apache.commons/commons-text@8.3.23"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-18
     tags:
       - frontend
@@ -4572,7 +4572,7 @@ vulnerabilities:
       - 1.0.3
     packages: ["pkg:npm/next@9.20.39"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-05
         vuln_ids: [GHSA-perf00754-extra-0]
         suppress: {}
@@ -4615,7 +4615,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-02-24
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-23
         vuln_ids: [GHSA-perf00751-extra-1]
     tags:
@@ -4635,7 +4635,7 @@ vulnerabilities:
       - "pkg:npm/serialize-javascript@3.16.29"
       - "pkg:golang/github.com/labstack/echo@3.16.29"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-08
       - reporter: trivy
         at: 2024-04-05
@@ -4839,7 +4839,7 @@ vulnerabilities:
         at: 2024-03-19
       - reporter: npm-audit
         at: 2024-03-16
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-16
         vuln_ids: [GHSA-perf00739-extra-2]
 
@@ -4956,7 +4956,7 @@ vulnerabilities:
       - 1.0.4
     packages: ["pkg:maven/io.netty/netty-handler@14.30.38"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-22
       - reporter: trivy
         at: 2024-02-20
@@ -4998,7 +4998,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-03-11
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-11
     analysis: Affected configuration option is hard-coded to a safe value in our build.
     analyzed_at: 2024-03-25
@@ -5123,7 +5123,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:maven/tools.jackson.core/jackson-databind@8.1.8"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-15
         vuln_ids: [GHSA-perf00724-extra-0]
     tags: [sdk]
@@ -5229,7 +5229,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-02-07
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
         vuln_ids: [GHSA-perf00718-extra-1]
     analysis: Input to the HTTP layer is validated and never originates from untrusted sources.
@@ -5265,7 +5265,7 @@ vulnerabilities:
       - "pkg:maven/io.netty/netty-handler@10.18.33"
       - "pkg:npm/braces@10.18.33"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-27
     analysis: This dependency is loaded only by the CI pipeline and never reaches production.
     analyzed_at: 2024-03-09
@@ -5494,7 +5494,7 @@ vulnerabilities:
     releases: [1.1.1]
     packages: ["pkg:maven/org.springframework/spring-web@3.6.18"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-24
       - reporter: snyk
         at: 2024-01-25
@@ -5656,7 +5656,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:pypi/jinja2@5.17.7"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-21
       - reporter: semgrep
         at: 2024-01-24
@@ -5763,7 +5763,7 @@ vulnerabilities:
       - "pkg:maven/org.apache.commons/commons-lang3@5.19.10.Final"
       - "pkg:maven/mysql/mysql-connector-java@5.19.10.Final"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
         vuln_ids: [GHSA-perf00688-extra-0]
       - reporter: semgrep
@@ -5935,7 +5935,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-03-31
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-28
     tags: [dev dependency]
     analysis: Network access to the affected endpoint is restricted by the perimeter firewall.
@@ -5966,7 +5966,7 @@ vulnerabilities:
       - 1.0.7
     packages: ["pkg:golang/github.com/gin-gonic/gin@12.28.7"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-25
       - reporter: npm-audit
         at: 2024-03-27
@@ -6068,7 +6068,7 @@ vulnerabilities:
     reports:
       - reporter: snyk
         at: 2024-02-28
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-28
         vuln_ids: [GHSA-perf00671-extra-1]
       - reporter: semgrep
@@ -6089,7 +6089,7 @@ vulnerabilities:
       - "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@0.4.28"
       - "pkg:npm/postcss@0.4.28"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-21
       - reporter: trivy
         at: 2024-01-19
@@ -6112,7 +6112,7 @@ vulnerabilities:
       - "pkg:pypi/django@12.28.25"
       - "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@12.28.25"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-30
       - reporter: npm-audit
         at: 2024-04-28
@@ -6133,7 +6133,7 @@ vulnerabilities:
       - "pkg:npm/react@1.27.0"
       - "pkg:docker/library/alpine@1.27.0"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-31
       - reporter: grype
         at: 2024-01-30
@@ -6145,7 +6145,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:maven/org.slf4j/slf4j-api@0.24.15"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
       - reporter: dependency-check
         at: 2024-02-01
@@ -6499,7 +6499,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:maven/org.springframework/spring-core@3.7.24"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-14
         suppress: {}
       - reporter: cargo-audit
@@ -6530,7 +6530,7 @@ vulnerabilities:
     releases: [1.1.0]
     packages: ["pkg:maven/org.bouncycastle/bcprov-jdk18on@8.8.9"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-03
         vuln_ids: [GHSA-perf00645-extra-0]
       - reporter: cargo-audit
@@ -6551,7 +6551,7 @@ vulnerabilities:
         at: 2024-03-21
       - reporter: trivy
         at: 2024-03-21
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-18
     analysis: "Risk accepted: the impacted code path is gated behind build-only authentication."
     analyzed_at: 2024-03-20
@@ -6581,7 +6581,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-01-21
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-20
         vuln_ids: [GHSA-perf00642-extra-1]
     tags: [test-infra]
@@ -6667,7 +6667,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:npm/qs@10.4.13"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-02
         vuln_ids: [GHSA-perf00638-extra-0]
         suppress:
@@ -6848,7 +6848,7 @@ vulnerabilities:
     releases: [1.0.2]
     packages: ["pkg:maven/io.netty/netty-buffer@4.10.37.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-27
         vuln_ids: [GHSA-perf00629-extra-0]
     tags: [backend]
@@ -6862,7 +6862,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@4.5.38-SNAPSHOT"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-28
     tags: [container]
 
@@ -6934,7 +6934,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-03-31
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-01
         vuln_ids: [GHSA-perf00624-extra-1]
       - reporter: semgrep
@@ -7020,7 +7020,7 @@ vulnerabilities:
       - 1.1.0
     packages: ["pkg:golang/github.com/gin-gonic/gin@10.3.37"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-28
         vuln_ids: [GHSA-perf00619-extra-0]
         suppress: {}
@@ -7115,7 +7115,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:docker/library/debian@9.23.6"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-20
         vuln_ids: [GHSA-perf00614-extra-0]
     tags: [build-dep]
@@ -7153,7 +7153,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-04-04
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-06
         vuln_ids: [GHSA-perf00612-extra-1]
     tags:
@@ -7253,7 +7253,7 @@ vulnerabilities:
         at: 2024-01-30
         suppress:
           expires_at: 2024-07-04
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-30
         suppress:
           expires_at: 2024-08-12
@@ -7324,7 +7324,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-02-16
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-16
       - reporter: npm-audit
         at: 2024-02-21
@@ -7342,7 +7342,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-03-08
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-12
         vuln_ids: [GHSA-perf00602-extra-1]
     tags:
@@ -7381,7 +7381,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:cargo/serde_json@8.4.16"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-29
     tags:
       - frontend
@@ -7431,7 +7431,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-04-13
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-13
     tags:
       - container
@@ -7499,7 +7499,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-01-14
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-10
 
   - id: CVE-2025-100592
@@ -7578,7 +7578,7 @@ vulnerabilities:
       - 1.0.3
     packages: ["pkg:maven/tools.jackson.core/jackson-databind@2.0.9"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
         suppress: {}
     tags: [ci-only]
@@ -7595,7 +7595,7 @@ vulnerabilities:
       - "pkg:npm/glob-parent@6.18.2-SNAPSHOT"
       - "pkg:golang/github.com/docker/docker@6.18.2-SNAPSHOT"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-29
         vuln_ids: [GHSA-perf00588-extra-0]
     tags:
@@ -7664,7 +7664,7 @@ vulnerabilities:
       - "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@5.14.12"
       - "pkg:cargo/tokio@5.14.12"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-04
         vuln_ids: [GHSA-perf00584-extra-0]
         suppress:
@@ -7697,7 +7697,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-02-08
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-07
         vuln_ids: [GHSA-perf00582-extra-1]
       - reporter: cargo-audit
@@ -7772,7 +7772,7 @@ vulnerabilities:
         at: 2024-02-24
       - reporter: cargo-audit
         at: 2024-02-24
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-20
     tags: [ci-only]
     analysis: We disable the affected XInclude processing at startup, so the issue cannot be triggered.
@@ -7792,7 +7792,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-01-15
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
     tags: [backend]
     analysis: "Risk accepted: the impacted code path is gated behind test-only authentication."
@@ -7825,7 +7825,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:maven/com.squareup.retrofit2/retrofit@5.18.24"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-02
         vuln_ids: [GHSA-perf00575-extra-0]
       - reporter: grype
@@ -7885,7 +7885,7 @@ vulnerabilities:
       - 1.1.1
     packages: ["pkg:pypi/numpy@14.23.7"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-11
       - reporter: snyk
         at: 2024-04-08
@@ -7961,7 +7961,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-01-25
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-25
         vuln_ids: [GHSA-perf00568-extra-1]
     analysis: We disable the affected JNDI lookups at startup, so the issue cannot be triggered.
@@ -7980,7 +7980,7 @@ vulnerabilities:
       - 1.0.5
     packages: ["pkg:generic/curl/curl@11.8.1"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-20
         suppress:
           expires_at: 2024-09-05
@@ -8136,7 +8136,7 @@ vulnerabilities:
       - 1.0.5
     packages: ["pkg:npm/svelte@0.20.17"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-08
       - reporter: grype
         at: 2024-02-07
@@ -8303,7 +8303,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:pypi/urllib3@3.17.14"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-06
         vuln_ids: [GHSA-perf00550-extra-0]
         suppress: {}
@@ -8339,7 +8339,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:maven/io.netty/netty-codec-http@1.7.27.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-16
         vuln_ids: [GHSA-perf00548-extra-0]
 
@@ -8563,7 +8563,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-01-12
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-13
         vuln_ids: [GHSA-perf00536-extra-1]
     analysis: Our deployment uses mTLS between services, which blocks the attack vector described in the advisory.
@@ -8612,7 +8612,7 @@ vulnerabilities:
       - "pkg:cargo/tokio@5.28.34"
       - "pkg:golang/k8s.io/client-go@5.28.34"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-20
         vuln_ids: [GHSA-perf00533-extra-0]
       - reporter: semgrep
@@ -8679,7 +8679,7 @@ vulnerabilities:
         at: 2024-03-14
         suppress:
           expires_at: 2024-10-13
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-11
         vuln_ids: [GHSA-perf00530-extra-2]
         suppress: {}
@@ -8699,7 +8699,7 @@ vulnerabilities:
       - "pkg:maven/ch.qos.logback.contrib/logback-jackson@3.7.13-SNAPSHOT"
       - "pkg:npm/tough-cookie@3.7.13-SNAPSHOT"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-20
         vuln_ids: [GHSA-perf00529-extra-0]
         suppress:
@@ -8737,7 +8737,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:maven/org.springframework.boot/spring-boot-starter-web@6.30.17"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-04
         vuln_ids: [GHSA-perf00527-extra-0]
     tags: [build-dep]
@@ -8757,7 +8757,7 @@ vulnerabilities:
       - "pkg:pypi/cryptography@2.19.5"
       - "pkg:npm/serialize-javascript@2.19.5"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-21
         vuln_ids: [GHSA-perf00526-extra-0]
       - reporter: grype
@@ -8874,7 +8874,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-03-07
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-09
     tags: [binary]
     analysis: The vulnerable encoder is not reachable in our configuration.
@@ -9034,7 +9034,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-03-23
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-21
         vuln_ids: [GHSA-perf00511-extra-1]
     tags:
@@ -9360,7 +9360,7 @@ vulnerabilities:
       - "pkg:cargo/tokio@11.11.0"
       - "pkg:npm/svelte@11.11.0"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-04
     tags: [ci-only]
     analysis: The vulnerable code path requires an attacker on the same host, which our application does not satisfy.
@@ -9398,7 +9398,7 @@ vulnerabilities:
       - 1.0.6
     packages: ["pkg:maven/org.apache.tomcat/tomcat-coyote@14.28.32"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-21
       - reporter: snyk
         at: 2024-03-21
@@ -9420,7 +9420,7 @@ vulnerabilities:
         at: 2024-04-12
       - reporter: trivy
         at: 2024-04-16
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-11
         vuln_ids: [GHSA-perf00490-extra-2]
     tags:
@@ -9460,7 +9460,7 @@ vulnerabilities:
     reports:
       - reporter: cargo-audit
         at: 2024-04-14
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-12
     tags:
       - container
@@ -9543,7 +9543,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:pypi/pandas@13.24.39.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-30
         vuln_ids: [GHSA-perf00483-extra-0]
       - reporter: semgrep
@@ -9568,7 +9568,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:pypi/requests@4.4.34-SNAPSHOT"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-23
         vuln_ids: [GHSA-perf00482-extra-0]
       - reporter: grype
@@ -9722,7 +9722,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-02-11
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-10
         vuln_ids: [GHSA-perf00474-extra-1]
     tags: [dev dependency]
@@ -9790,7 +9790,7 @@ vulnerabilities:
       - 1.0.5
     packages: ["pkg:maven/org.yaml/snakeyaml@13.20.20"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-20
       - reporter: grype
         at: 2024-02-17
@@ -9941,7 +9941,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:maven/org.slf4j/slf4j-api@10.26.33"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-31
         vuln_ids: [GHSA-perf00463-extra-0]
       - reporter: grype
@@ -9965,7 +9965,7 @@ vulnerabilities:
       - reporter: snyk
         at: 2024-01-29
         vuln_ids: [SNYK-JAVA-PERF-700462-1]
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-29
     analysis: We disable the affected auto-discovery at startup, so the issue cannot be triggered.
     analyzed_at: 2024-02-05
@@ -9986,7 +9986,7 @@ vulnerabilities:
       - "pkg:maven/commons-fileupload/commons-fileupload@0.17.1"
       - "pkg:npm/react-dom@0.17.1"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-24
         vuln_ids: [GHSA-perf00461-extra-0]
       - reporter: dependency-check
@@ -10023,7 +10023,7 @@ vulnerabilities:
       - "pkg:npm/react-dom@5.14.24"
       - "pkg:npm/react@5.14.24"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-22
         vuln_ids: [GHSA-perf00459-extra-0]
       - reporter: dependency-check
@@ -10044,7 +10044,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-01-24
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-24
         vuln_ids: [GHSA-perf00458-extra-1]
     tags: [dev dependency]
@@ -10091,7 +10091,7 @@ vulnerabilities:
       - 1.1.0
     packages: ["pkg:npm/node-fetch@10.19.28"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-28
         vuln_ids: [GHSA-perf00455-extra-0]
       - reporter: npm-audit
@@ -10112,7 +10112,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-02-26
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-25
         vuln_ids: [GHSA-perf00454-extra-1]
     analysis: The vulnerable encoder is not reachable in our configuration.
@@ -10152,7 +10152,7 @@ vulnerabilities:
       - 1.0.4
     packages: ["pkg:docker/library/alpine@2.19.2.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-11
         suppress: {}
       - reporter: semgrep
@@ -10174,7 +10174,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:maven/com.google.protobuf/protobuf-java@2.28.7"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-29
         vuln_ids: [GHSA-perf00451-extra-0]
     analysis: "Risk accepted: the impacted code path is gated behind CI-only authentication."
@@ -10273,7 +10273,7 @@ vulnerabilities:
     reports:
       - reporter: snyk
         at: 2024-02-07
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-08
         vuln_ids: [GHSA-perf00446-extra-1]
     analysis: The vulnerable code path requires an attacker on the same host, which our application does not satisfy.
@@ -10344,7 +10344,7 @@ vulnerabilities:
     releases: [1.0.7]
     packages: ["pkg:npm/jsonwebtoken@6.30.37"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-19
     tags: [dev dependency]
     analysis: We disable the affected JNDI lookups at startup, so the issue cannot be triggered.
@@ -10497,7 +10497,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:maven/org.apache.logging.log4j/log4j-core@3.24.15"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-22
         vuln_ids: [GHSA-perf00433-extra-0]
     tags:
@@ -10602,7 +10602,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-03-14
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-15
     tags: [binary]
     analysis: The vulnerable code path requires an attacker on the same host, which our application does not satisfy.
@@ -10768,7 +10768,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-02-12
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-14
         vuln_ids: [GHSA-perf00419-extra-1]
         suppress:
@@ -10806,7 +10806,7 @@ vulnerabilities:
     reports:
       - reporter: cargo-audit
         at: 2024-02-09
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-05
         vuln_ids: [GHSA-perf00417-extra-1]
       - reporter: grype
@@ -11038,7 +11038,7 @@ vulnerabilities:
       - reporter: dependency-check
         at: 2024-01-19
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-24
         vuln_ids: [GHSA-perf00405-extra-1]
         suppress: {}
@@ -11101,7 +11101,7 @@ vulnerabilities:
       - 1.0.5
     packages: ["pkg:maven/com.google.protobuf/protobuf-java@9.3.3"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-01
         vuln_ids: [GHSA-perf00402-extra-0]
       - reporter: cargo-audit
@@ -11144,7 +11144,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:npm/body-parser@8.22.40.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-30
         suppress:
           expires_at: 2024-05-18
@@ -11185,7 +11185,7 @@ vulnerabilities:
         at: 2024-01-29
       - reporter: semgrep
         at: 2024-01-29
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-02
     analysis: Network access to the affected endpoint is restricted by the perimeter firewall.
     analyzed_at: 2024-02-12
@@ -11207,7 +11207,7 @@ vulnerabilities:
       - "pkg:maven/com.google.protobuf/protobuf-java-util@8.2.36"
       - "pkg:golang/k8s.io/apimachinery@8.2.36"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-31
         vuln_ids: [GHSA-perf00397-extra-0]
     tags: [build-dep]
@@ -11225,7 +11225,7 @@ vulnerabilities:
     releases: [1.0.2]
     packages: ["pkg:maven/org.jetbrains.kotlinx/kotlinx-coroutines-core@1.8.14"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-17
         vuln_ids: [GHSA-perf00396-extra-0]
         suppress: {}
@@ -11269,7 +11269,7 @@ vulnerabilities:
           expires_at: 2024-11-22
       - reporter: grype
         at: 2024-03-21
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-20
         vuln_ids: [GHSA-perf00394-extra-2]
         suppress:
@@ -11394,7 +11394,7 @@ vulnerabilities:
       - "pkg:maven/commons-codec/commons-codec@13.22.10"
       - "pkg:generic/curl/curl@13.22.10"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-20
       - reporter: grype
         at: 2024-03-22
@@ -11430,7 +11430,7 @@ vulnerabilities:
     releases: [1.0.7]
     packages: ["pkg:maven/com.fasterxml.jackson.core/jackson-annotations@1.14.5"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-17
       - reporter: semgrep
         at: 2024-03-20
@@ -11733,7 +11733,7 @@ vulnerabilities:
     releases: [1.0.7]
     packages: ["pkg:npm/yargs-parser@8.24.31"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-16
         vuln_ids: [GHSA-perf00369-extra-0]
       - reporter: grype
@@ -11814,7 +11814,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:maven/org.bouncycastle/bcpkix-jdk18on@14.17.1"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-19
         vuln_ids: [GHSA-perf00365-extra-0]
       - reporter: dependency-check
@@ -11833,7 +11833,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:maven/com.google.guava/guava@8.30.38"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-21
         vuln_ids: [GHSA-perf00364-extra-0]
     tags: [test-infra]
@@ -11867,7 +11867,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:npm/next@7.21.7"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-24
       - reporter: dependency-check
         at: 2024-02-26
@@ -11966,7 +11966,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:npm/qs@12.17.21"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-23
         vuln_ids: [GHSA-perf00356-extra-0]
         suppress: {}
@@ -12059,7 +12059,7 @@ vulnerabilities:
     releases: [1.1.1]
     packages: ["pkg:maven/org.postgresql/postgresql@14.12.3"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-01
         vuln_ids: [GHSA-perf00351-extra-0]
       - reporter: grype
@@ -12148,7 +12148,7 @@ vulnerabilities:
       - reporter: trivy
         at: 2024-02-09
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-11
         vuln_ids: [GHSA-perf00346-extra-1]
         suppress: {}
@@ -12256,7 +12256,7 @@ vulnerabilities:
       - "pkg:maven/org.slf4j/slf4j-api@12.24.32"
       - "pkg:maven/org.apache.commons/commons-compress@12.24.32"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-04
         vuln_ids: [GHSA-perf00339-extra-0]
       - reporter: trivy
@@ -12274,7 +12274,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:maven/org.apache.logging.log4j/log4j-core@8.10.22-SNAPSHOT"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-24
         suppress:
           expires_at: 2024-06-16
@@ -12294,7 +12294,7 @@ vulnerabilities:
         at: 2024-01-18
       - reporter: npm-audit
         at: 2024-01-18
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-16
         vuln_ids: [GHSA-perf00337-extra-2]
     analysis: Affected configuration option is hard-coded to a safe value in our build.
@@ -12323,7 +12323,7 @@ vulnerabilities:
     releases: [1.1.2]
     packages: ["pkg:maven/org.eclipse.jetty/jetty-server@14.10.32"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-02
         vuln_ids: [GHSA-perf00335-extra-0]
       - reporter: trivy
@@ -12342,7 +12342,7 @@ vulnerabilities:
     releases: [1.0.6]
     packages: ["pkg:maven/com.squareup.retrofit2/retrofit@11.27.19"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-01
       - reporter: grype
         at: 2024-04-02
@@ -12367,7 +12367,7 @@ vulnerabilities:
       - "pkg:npm/minimist@5.23.18"
       - "pkg:pypi/urllib3@5.23.18"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-24
       - reporter: cargo-audit
         at: 2024-03-23
@@ -12515,7 +12515,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:maven/mysql/mysql-connector-java@8.7.38"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-04
         vuln_ids: [GHSA-perf00323-extra-0]
       - reporter: grype
@@ -12542,7 +12542,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-03-07
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-03
         vuln_ids: [GHSA-perf00322-extra-1]
     tags:
@@ -12803,7 +12803,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:npm/micromatch@7.7.25"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-24
         vuln_ids: [GHSA-perf00307-extra-0]
 
@@ -12853,7 +12853,7 @@ vulnerabilities:
         at: 2024-02-08
       - reporter: grype
         at: 2024-02-09
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-09
 
   - id: CVE-2022-100303
@@ -12866,7 +12866,7 @@ vulnerabilities:
       - "pkg:cargo/regex@4.0.0"
       - "pkg:npm/minimist@4.0.0"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-21
         suppress:
           expires_at: 2025-01-21
@@ -12932,7 +12932,7 @@ vulnerabilities:
         at: 2024-01-23
       - reporter: snyk
         at: 2024-01-25
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-26
     tags:
       - backend
@@ -13152,7 +13152,7 @@ vulnerabilities:
         at: 2024-02-26
       - reporter: trivy
         at: 2024-02-27
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-26
         vuln_ids: [GHSA-perf00288-extra-2]
 
@@ -13251,7 +13251,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-02-06
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-05
         vuln_ids: [GHSA-perf00282-extra-1]
     tags: [backend]
@@ -13311,7 +13311,7 @@ vulnerabilities:
     releases: [1.0.2]
     packages: ["pkg:npm/axios@14.13.19"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-18
     tags: [sdk]
 
@@ -13343,7 +13343,7 @@ vulnerabilities:
       - 1.0.3
     packages: ["pkg:pypi/sqlalchemy@14.24.5.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-19
         vuln_ids: [GHSA-perf00277-extra-0]
       - reporter: trivy
@@ -13405,7 +13405,7 @@ vulnerabilities:
       - reporter: trivy
         at: 2024-02-22
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-26
         vuln_ids: [GHSA-perf00273-extra-1]
         suppress:
@@ -13445,7 +13445,7 @@ vulnerabilities:
       - reporter: dependency-check
         at: 2024-02-04
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-30
     tags: [transitive]
     analysis: This dependency is loaded only by the dev-only pipeline and never reaches production.
@@ -13526,7 +13526,7 @@ vulnerabilities:
       - "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@7.21.9"
       - "pkg:maven/com.squareup.retrofit2/retrofit@7.21.9"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-01
         vuln_ids: [GHSA-perf00266-extra-0]
     tags: [test-infra]
@@ -13625,7 +13625,7 @@ vulnerabilities:
       - "pkg:maven/com.squareup.okhttp3/okhttp@10.16.25"
       - "pkg:cargo/reqwest@10.16.25"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-15
         vuln_ids: [GHSA-perf00260-extra-0]
     tags:
@@ -13658,7 +13658,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-03-15
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-13
       - reporter: snyk
         at: 2024-03-10
@@ -13742,7 +13742,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:maven/org.springframework/spring-core@14.18.19"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-20
         vuln_ids: [GHSA-perf00254-extra-0]
       - reporter: semgrep
@@ -13803,7 +13803,7 @@ vulnerabilities:
       - reporter: snyk
         at: 2024-02-29
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-29
         suppress: {}
       - reporter: trivy
@@ -13822,7 +13822,7 @@ vulnerabilities:
     releases: [1.0.5]
     packages: ["pkg:maven/com.fasterxml.jackson.core/jackson-databind@10.20.5"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-23
         vuln_ids: [GHSA-perf00250-extra-0]
     tags: [test-infra]
@@ -13897,7 +13897,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-01-13
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-15
     tags: [transitive]
     analysis: We disable the affected dynamic SQL at startup, so the issue cannot be triggered.
@@ -13948,7 +13948,7 @@ vulnerabilities:
       - "pkg:pypi/urllib3@0.11.18"
       - "pkg:maven/org.springframework.boot/spring-boot@0.11.18"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-15
       - reporter: snyk
         at: 2024-01-14
@@ -13973,7 +13973,7 @@ vulnerabilities:
       - "pkg:maven/com.h2database/h2@0.12.14"
       - "pkg:pypi/numpy@0.12.14"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-19
     analysis: We disable the affected JNDI lookups at startup, so the issue cannot be triggered.
     analyzed_at: 2024-02-29
@@ -14060,7 +14060,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:maven/io.netty/netty-buffer@7.19.24"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-02
         vuln_ids: [GHSA-perf00237-extra-0]
         suppress: {}
@@ -14077,7 +14077,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:maven/io.jsonwebtoken/jjwt-impl@10.4.22-SNAPSHOT"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-18
         vuln_ids: [GHSA-perf00236-extra-0]
       - reporter: cargo-audit
@@ -14116,7 +14116,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:cargo/tokio@6.29.27"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-04
       - reporter: trivy
         at: 2024-03-02
@@ -14182,7 +14182,7 @@ vulnerabilities:
     releases: [1.1.0]
     packages: ["pkg:docker/library/alpine@10.19.17"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-06
         suppress:
           expires_at: 2024-09-11
@@ -14200,7 +14200,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:docker/library/postgres@6.28.17"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-24
         vuln_ids: [GHSA-perf00229-extra-0]
       - reporter: cargo-audit
@@ -14279,7 +14279,7 @@ vulnerabilities:
       - reporter: trivy
         at: 2024-02-27
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-29
         vuln_ids: [GHSA-perf00225-extra-1]
         suppress: {}
@@ -14301,7 +14301,7 @@ vulnerabilities:
       - 1.0.4
     packages: ["pkg:npm/react@4.13.12"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-23
         vuln_ids: [GHSA-perf00224-extra-0]
       - reporter: dependency-check
@@ -14323,7 +14323,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-01-21
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-20
         vuln_ids: [GHSA-perf00223-extra-1]
       - reporter: snyk
@@ -14380,7 +14380,7 @@ vulnerabilities:
       - "pkg:docker/library/redis@5.18.31"
       - "pkg:npm/jsonwebtoken@5.18.31"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-14
         vuln_ids: [GHSA-perf00220-extra-0]
     analysis: "Risk accepted: the impacted code path is gated behind test-only authentication."
@@ -14430,7 +14430,7 @@ vulnerabilities:
         at: 2024-01-18
       - reporter: snyk
         at: 2024-01-15
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-14
         vuln_ids: [GHSA-perf00217-extra-2]
     analysis: We disable the affected XInclude processing at startup, so the issue cannot be triggered.
@@ -14472,7 +14472,7 @@ vulnerabilities:
       - 1.1.0
     packages: ["pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@2.9.9"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-05
         vuln_ids: [GHSA-perf00214-extra-0]
       - reporter: trivy
@@ -14520,7 +14520,7 @@ vulnerabilities:
         at: 2024-02-08
       - reporter: cargo-audit
         at: 2024-02-09
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-06
         vuln_ids: [GHSA-perf00212-extra-2]
     tags: [container]
@@ -14595,7 +14595,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-02-09
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-11
     analysis: The vulnerable code path requires an attacker on the same host, which our application does not satisfy.
     analyzed_at: 2024-02-19
@@ -14628,7 +14628,7 @@ vulnerabilities:
     releases: [1.1.1]
     packages: ["pkg:maven/org.apache.commons/commons-compress@1.19.26"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-07
 
   - id: GHSA-perf00205-bbbb-7481
@@ -14685,7 +14685,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:golang/k8s.io/apimachinery@14.30.28"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-09
         suppress: {}
     tags: [dev dependency]
@@ -14742,7 +14742,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-01-25
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-25
       - reporter: snyk
         at: 2024-01-27
@@ -14771,7 +14771,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-03-25
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-28
     tags:
       - test-infra
@@ -14795,7 +14795,7 @@ vulnerabilities:
     reports:
       - reporter: npm-audit
         at: 2024-02-12
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-13
     tags: [frontend]
     analysis: The vulnerable code path requires anonymous write access, which our application does not satisfy.
@@ -14828,7 +14828,7 @@ vulnerabilities:
       - reporter: dependency-check
         at: 2024-02-09
         suppress: {}
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-10
         vuln_ids: [GHSA-perf00195-extra-1]
     tags: [frontend]
@@ -15002,7 +15002,7 @@ vulnerabilities:
       - "pkg:docker/library/alpine@7.18.10"
       - "pkg:golang/google.golang.org/grpc@7.18.10"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-07
       - reporter: cargo-audit
         at: 2024-02-07
@@ -15092,7 +15092,7 @@ vulnerabilities:
     releases: [1.0.2]
     packages: ["pkg:maven/io.netty/netty-codec-http@7.21.27"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-05
         vuln_ids: [GHSA-perf00180-extra-0]
     tags: [backend]
@@ -15225,7 +15225,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-01-26
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-26
         vuln_ids: [GHSA-perf00173-extra-1]
     tags: [ci-only]
@@ -15406,7 +15406,7 @@ vulnerabilities:
       - 1.1.1
     packages: ["pkg:maven/io.jsonwebtoken/jjwt-impl@9.22.21"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-04
     tags: [build-dep]
     analysis: This dependency is loaded only by the internal admin pipeline and never reaches production.
@@ -15442,7 +15442,7 @@ vulnerabilities:
       - 1.0.2
     packages: ["pkg:golang/github.com/gin-gonic/gin@6.29.26"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-15
         vuln_ids: [GHSA-perf00161-extra-0]
         suppress: {}
@@ -15474,7 +15474,7 @@ vulnerabilities:
       - 1.0.5
     packages: ["pkg:npm/express@1.12.11"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-01
     analysis: Input to the queue consumer is validated and never originates from untrusted sources.
     analyzed_at: 2024-03-01
@@ -15545,7 +15545,7 @@ vulnerabilities:
       - "pkg:cargo/regex@1.2.1.Final"
       - "pkg:npm/express@1.2.1.Final"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
         vuln_ids: [GHSA-perf00156-extra-0]
     tags:
@@ -15568,7 +15568,7 @@ vulnerabilities:
         at: 2024-04-04
       - reporter: semgrep
         at: 2024-03-30
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-04
         vuln_ids: [GHSA-perf00155-extra-2]
     analysis: Our deployment uses a strict WAF policy, which blocks the attack vector described in the advisory.
@@ -15636,7 +15636,7 @@ vulnerabilities:
     releases: [1.0.7]
     packages: ["pkg:maven/commons-fileupload/commons-fileupload@2.13.22-SNAPSHOT"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-13
         vuln_ids: [GHSA-perf00151-extra-0]
 
@@ -15689,7 +15689,7 @@ vulnerabilities:
     reports:
       - reporter: cargo-audit
         at: 2024-03-21
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-18
         vuln_ids: [GHSA-perf00148-extra-1]
     tags: [dev dependency]
@@ -15726,7 +15726,7 @@ vulnerabilities:
       - "pkg:maven/org.apache.commons/commons-text@10.26.1"
       - "pkg:golang/github.com/docker/docker@10.26.1"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-26
       - reporter: trivy
         at: 2024-01-25
@@ -15766,7 +15766,7 @@ vulnerabilities:
         vuln_ids: [SNYK-JAVA-PERF-700144-0]
       - reporter: semgrep
         at: 2024-02-18
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-17
     analysis: Input to the queue consumer is validated and never originates from untrusted sources.
     analyzed_at: 2024-02-28
@@ -15852,7 +15852,7 @@ vulnerabilities:
       - 1.0.7
     packages: ["pkg:maven/io.grpc/grpc-netty@5.0.33"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-17
         vuln_ids: [GHSA-perf00140-extra-0]
     tags: [ci-only]
@@ -15941,7 +15941,7 @@ vulnerabilities:
         suppress: {}
       - reporter: cargo-audit
         at: 2024-02-22
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-20
         suppress: {}
     tags: [test-infra]
@@ -15960,7 +15960,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-04-11
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-13
         vuln_ids: [GHSA-perf00134-extra-1]
     tags: [transitive]
@@ -16153,7 +16153,7 @@ vulnerabilities:
     releases: [1.0.4]
     packages: ["pkg:maven/org.bouncycastle/bcprov-jdk18on@2.9.24"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-21
       - reporter: trivy
         at: 2024-02-18
@@ -16175,7 +16175,7 @@ vulnerabilities:
       - 1.1.1
     packages: ["pkg:maven/com.google.protobuf/protobuf-java@14.13.5"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-11
         vuln_ids: [GHSA-perf00122-extra-0]
     tags: [dev dependency]
@@ -16289,7 +16289,7 @@ vulnerabilities:
       - "pkg:pypi/requests@5.7.20"
       - "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@5.7.20"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-22
         suppress:
           expires_at: 2024-07-19
@@ -16480,7 +16480,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:npm/node-fetch@10.12.10"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-07
         vuln_ids: [GHSA-perf00107-extra-0]
         suppress: {}
@@ -16622,7 +16622,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:maven/org.springframework.security/spring-security-core@4.24.20"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-19
       - reporter: trivy
         at: 2024-01-15
@@ -16638,7 +16638,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-03-07
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-06
         vuln_ids: [GHSA-perf00097-extra-1]
         suppress: {}
@@ -16697,7 +16697,7 @@ vulnerabilities:
     reports:
       - reporter: trivy
         at: 2024-04-02
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-02
     tags: [transitive]
     analysis: The vulnerable parser is not reachable in our configuration.
@@ -16852,7 +16852,7 @@ vulnerabilities:
     reports:
       - reporter: grype
         at: 2024-04-06
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-03
     tags:
       - transitive
@@ -16871,7 +16871,7 @@ vulnerabilities:
       - "pkg:maven/org.eclipse.jetty/jetty-server@12.9.17"
       - "pkg:docker/library/postgres@12.9.17"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-27
         suppress:
           expires_at: 2024-09-11
@@ -16902,7 +16902,7 @@ vulnerabilities:
     releases: [1.0.3]
     packages: ["pkg:maven/io.netty/netty-handler@6.16.3"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-12
     tags:
       - sdk
@@ -16958,7 +16958,7 @@ vulnerabilities:
       - reporter: snyk
         at: 2024-01-10
         vuln_ids: [SNYK-JAVA-PERF-700079-1]
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
     analysis: The vulnerable code path requires an attacker on the same host, which our application does not satisfy.
     analyzed_at: 2024-01-17
@@ -17065,7 +17065,7 @@ vulnerabilities:
       - "pkg:generic/libxml2/libxml2@12.8.15"
       - "pkg:golang/github.com/docker/docker@12.8.15"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-04-07
         vuln_ids: [GHSA-perf00073-extra-0]
       - reporter: snyk
@@ -17115,7 +17115,7 @@ vulnerabilities:
     reports:
       - reporter: dependency-check
         at: 2024-03-12
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-10
       - reporter: trivy
         at: 2024-03-14
@@ -17181,7 +17181,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:docker/library/alpine@11.27.5"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-12
         vuln_ids: [GHSA-perf00066-extra-0]
     analysis: This dependency is loaded only by the internal admin pipeline and never reaches production.
@@ -17197,7 +17197,7 @@ vulnerabilities:
       - 1.1.2
     packages: ["pkg:maven/org.apache.logging.log4j/log4j-core@12.3.10.Final"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-09
         vuln_ids: [GHSA-perf00065-extra-0]
         suppress:
@@ -17327,7 +17327,7 @@ vulnerabilities:
       - "pkg:maven/io.netty/netty-codec-http@4.14.18"
       - "pkg:maven/org.jetbrains.kotlin/kotlin-reflect@4.14.18"
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-12
         vuln_ids: [GHSA-perf00058-extra-0]
       - reporter: cargo-audit
@@ -17613,7 +17613,7 @@ vulnerabilities:
     releases: [1.1.1]
     packages: ["pkg:npm/node-fetch@10.3.28"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-09
         vuln_ids: [GHSA-perf00041-extra-0]
     tags: [binary]
@@ -17775,7 +17775,7 @@ vulnerabilities:
       - reporter: snyk
         at: 2024-03-07
         vuln_ids: [SNYK-JAVA-PERF-700033-1]
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-09
     analysis: Input to the HTTP layer is validated and never originates from untrusted sources.
     analyzed_at: 2024-03-08
@@ -17808,7 +17808,7 @@ vulnerabilities:
     releases: [1.0.1]
     packages: ["pkg:maven/org.bouncycastle/bcprov-jdk18on@1.27.9"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-19
 
   - id: SNYK-PERF-900030
@@ -17985,7 +17985,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-03-03
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-03-01
         vuln_ids: [GHSA-perf00021-extra-1]
     analysis: Affected configuration option is hard-coded to a safe value in our build.
@@ -18059,7 +18059,7 @@ vulnerabilities:
     reports:
       - reporter: cargo-audit
         at: 2024-02-09
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-08
         vuln_ids: [GHSA-perf00017-extra-1]
     analysis: The vulnerable filter is not reachable in our configuration.
@@ -18168,7 +18168,7 @@ vulnerabilities:
     reports:
       - reporter: semgrep
         at: 2024-01-10
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-10
         vuln_ids: [GHSA-perf00010-extra-1]
       - reporter: dependency-check
@@ -18190,7 +18190,7 @@ vulnerabilities:
       - 1.0.4
     packages: ["pkg:npm/json5@0.13.33"]
     reports:
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-02-02
         vuln_ids: [GHSA-perf00009-extra-0]
     tags: [test-infra]
@@ -18266,7 +18266,7 @@ vulnerabilities:
     reports:
       - reporter: cargo-audit
         at: 2024-01-16
-      - reporter: github-advisory
+      - reporter: github-dependabot
         at: 2024-01-16
     tags: [test-infra]
     analysis: "Risk accepted: the impacted code path is gated behind build-only authentication."

--- a/schema/v1/defs/common.json
+++ b/schema/v1/defs/common.json
@@ -118,8 +118,8 @@
           "const": "npm-audit"
         },
         {
-          "description": "GitHub Advisory Database. No suppression support",
-          "const": "github-advisory"
+          "description": "GitHub Dependabot. No suppression support",
+          "const": "github-dependabot"
         },
         {
           "description": "Generic or non-scanner source. Requires the 'source' field on the report entry",

--- a/schema/vulnlog-v1.json
+++ b/schema/vulnlog-v1.json
@@ -247,8 +247,8 @@
               "const": "npm-audit"
             },
             {
-              "description": "GitHub Advisory Database. No suppression support",
-              "const": "github-advisory"
+              "description": "GitHub Dependabot. No suppression support",
+              "const": "github-dependabot"
             },
             {
               "description": "Generic or non-scanner source. Requires the 'source' field on the report entry",


### PR DESCRIPTION
renamed 'github-advisory' reporter to 'github-dependabot' in the codebase and JSON schemas.
updated tests, docs, and configs to match. fixes #168.