### PR TITLE
fix: Do not write resolved vulnerabilities to suppression files

### DIFF
--- a/docs/modules/ROOT/pages/suppression.adoc
+++ b/docs/modules/ROOT/pages/suppression.adoc
@@ -22,45 +22,19 @@ See xref:ci-integration.adoc[CI/CD Integration] for pipeline examples using dyna
 
 == Suppression Rules
 
-Whether an entry appears in the generated suppression file depends on whether the vulnerability still impacts the release and whether the scanner is expected to stop reporting the finding on its own.
+Three rules decide whether an entry appears in the generated suppression file:
 
-The following table summarises every combination.
-The cases are explained in prose below.
+Resolved findings are never suppressed::
+Once a `resolution` is recorded, the vulnerable dependency is gone and the scanner stops reporting the finding on its own.
+These entries are excluded regardless of verdict or `suppress` block.
+If the scanner still reports one, the resolution is incomplete and should be fixed rather than suppressed.
 
-[cols="2,2,2,3"]
-|===
-| Verdict | Resolution | `suppress` block | In suppression file?
+`not affected` findings are always suppressed::
+The finding does not impact the release, so it is noise and is suppressed automatically -- no `suppress` block required.
 
-| `not affected`           | any     | not required | *Yes*
-| `affected`               | present | ignored      | *No* -- scanner stops reporting after the fix
-| `affected`               | absent  | absent       | *No* -- live risk, no deliberate decision
-| `affected`               | absent  | present      | *Yes* ^*^
-| `risk acceptable`        | any     | absent       | *No* -- live risk, no deliberate decision
-| `risk acceptable`        | any     | present      | *Yes* ^*^
-| _(absent, under investigation)_ | n/a | absent  | *No*
-| _(absent, under investigation)_ | n/a | present | *Yes* ^*^
-|===
-
-^*^ Excluded once `suppress.expires_at` is in the past.
-
-Verdict `not affected`::
-The vulnerability does not impact the release, so the scanner finding is effectively noise.
-These entries are always included in suppression files, no explicit `suppress` block required.
-
-Verdict `affected` with a `resolution`::
-The vulnerable dependency version is no longer present after the resolution, so the scanner is expected to stop reporting the finding.
-These entries are *not* included in suppression files.
-If the scanner still reports the finding, the resolution is incomplete and should be investigated rather than suppressed.
-
-All other cases (`affected` without resolution, `risk acceptable`, absent verdict)::
-The vulnerable code is still present and still impacts the release, or the impact has not yet been assessed.
-Suppressing the finding would hide a live or unknown risk, so it must be recorded as a deliberate decision separate from the verdict: an explicit `suppress` block on the report entry is required.
-
-If the `suppress` block includes `expires_at`, the suppression is temporary.
-If `expires_at` is omitted, the suppression is permanent.
-
-NOTE: State and suppression are orthogonal.
-Both `not affected` and `risk acceptable` yield the `dismissed` state (see xref:vulnerability-states.adoc[Vulnerability States]), but their suppression behavior differs: `not affected` represents noise and is always suppressed; `risk acceptable` represents a live risk, so suppression must be an explicit, separate decision.
+Everything else needs an explicit `suppress` block::
+`affected`, `risk acceptable`, and not-yet-triaged findings are still a live or unknown risk.
+Suppressing one is a deliberate decision, so it happens only when the report entry carries a `suppress` block.
 
 === Permanent Suppression
 

--- a/docs/modules/ROOT/pages/verdicts-and-justifications.adoc
+++ b/docs/modules/ROOT/pages/verdicts-and-justifications.adoc
@@ -50,7 +50,9 @@ resolution:
 The vulnerable dependency is present but does not impact the project.
 Requires a `justification` explaining why the vulnerability is not exploitable in this context.
 
-Because the finding does not reflect a real risk to the project, entries with this verdict are always included in generated suppression files without requiring an explicit `suppress` block.
+Because the finding does not reflect a real risk to the project, entries with this verdict are included in generated suppression files without requiring an explicit `suppress` block.
+
+If a `resolution` is also recorded, the entry is treated as resolved and excluded from generated suppression files -- the dependency was updated, so the scanner is expected to stop reporting the finding.
 
 [source,yaml]
 ----

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
@@ -84,7 +84,7 @@ private fun mergeTwo(
         fixedIn = a.fixedIn + b.fixedIn,
     )
 
-private fun findWorkState(
+fun findWorkState(
     vulnEntry: VulnerabilityEntry,
     filterReleases: Set<Release>,
 ): WorkState {

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
@@ -3,11 +3,12 @@
 
 package dev.vulnlog.lib.core
 
+import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReporterType
 import dev.vulnlog.lib.model.Verdict
-import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.model.report.WorkState
 import dev.vulnlog.lib.model.suppress.NotSuppressable
 import dev.vulnlog.lib.model.suppress.Suppressable
 import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
@@ -31,40 +32,36 @@ fun collectSuppressedVulnerabilities(
 ): Map<ReporterType, List<SuppressedVulnerability>> =
     vulnlogFile.vulnerabilities
         .asSequence()
-        .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today, filter.filter) }
+        .filterNot { vulnerability -> isResolved(vulnerability, filter.filter.releases) }
+        .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today) }
         .applyFilter(filter)
         .groupBy { it.reporter }
         .filter { filter.filter.reporter == null || it.key == filter.filter.reporter }
 
+private fun isResolved(
+    vulnEntry: VulnerabilityEntry,
+    filterReleases: Set<Release>,
+): Boolean = findWorkState(vulnEntry, filterReleases) == WorkState.RESOLVED
+
 private fun explodeAndMapToSuppressedVulnerabilities(
     vulnerability: VulnerabilityEntry,
     today: LocalDate,
-    filter: VulnlogFilter,
-): List<SuppressedVulnerability> {
-    if (vulnerability.verdict is Verdict.Affected && vulnerability.resolution != null) {
-        // When --release X is given, treat the resolution as effective only if it shipped at-or-before X.
-        // Without a release context, fall back to dropping unconditionally (the fix is the canonical answer).
-        val resolutionShipped =
-            filter.releases.isEmpty() || vulnerability.resolution.release in filter.releases
-        if (resolutionShipped) return emptyList()
-    }
-    return vulnerability.reports.flatMap { report ->
-        if (!isReportEligible(vulnerability.verdict, report.suppress, today)) {
-            return@flatMap emptyList()
+): List<SuppressedVulnerability> =
+    vulnerability.reports
+        .filter { report -> isReportEligible(vulnerability.verdict, report.suppress, today) }
+        .flatMap { report ->
+            val ids = report.vulnIds.ifEmpty { setOf(vulnerability.id) }
+            ids.map { id ->
+                SuppressedVulnerability(
+                    id = id,
+                    releases = vulnerability.releases,
+                    reporter = report.reporter,
+                    expiresAt = report.suppress?.expiresAt,
+                    tags = vulnerability.tags,
+                    analysis = vulnerability.analysis ?: "",
+                )
+            }
         }
-        val ids: Collection<VulnId> = report.vulnIds.ifEmpty { listOf(vulnerability.id) }
-        ids.map { id ->
-            SuppressedVulnerability(
-                id = id,
-                releases = vulnerability.releases,
-                reporter = report.reporter,
-                expiresAt = report.suppress?.expiresAt,
-                tags = vulnerability.tags,
-                analysis = vulnerability.analysis ?: "",
-            )
-        }
-    }
-}
 
 private fun isReportEligible(
     verdict: Verdict,

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionTest.kt
@@ -474,7 +474,7 @@ class SuppressionTest :
                 result shouldHaveSize 1
             }
 
-            test("not affected with resolution is still included") {
+            test("not affected with resolution is excluded") {
                 val vuln =
                     vulnerability(
                         verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
@@ -483,6 +483,20 @@ class SuppressionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+
+                result.shouldBeEmpty()
+            }
+
+            test("not affected with resolution outside the filter releases is still included") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
+                        resolution = Resolution(release = releaseV2),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
 
                 result shouldHaveSize 1
             }
@@ -500,7 +514,7 @@ class SuppressionTest :
                 result.shouldBeEmpty()
             }
 
-            test("risk acceptable with resolution is included when suppress block present") {
+            test("risk acceptable with resolution is excluded regardless of suppress block") {
                 val vuln =
                     vulnerability(
                         verdict = Verdict.RiskAcceptable(Severity.MEDIUM),
@@ -510,7 +524,7 @@ class SuppressionTest :
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result shouldHaveSize 1
+                result.shouldBeEmpty()
             }
 
             test("affected without resolution is included when suppress block present") {


### PR DESCRIPTION
A vulnerability is only considered resolved when it is not re-reported. Therefore, these entries should not be included in the suppression file.

fixes #170