### PR TITLE
feat: Write expired suppressions not to  suppression file (#169)

### DIFF
--- a/docs/modules/ROOT/pages/suppression.adoc
+++ b/docs/modules/ROOT/pages/suppression.adoc
@@ -22,15 +22,21 @@ See xref:ci-integration.adoc[CI/CD Integration] for pipeline examples using dyna
 
 == Suppression Rules
 
-Three rules decide whether an entry appears in the generated suppression file:
+Four rules decide whether an entry appears in the generated suppression file:
 
 Resolved findings are never suppressed::
 Once a `resolution` is recorded, the vulnerable dependency is gone and the scanner stops reporting the finding on its own.
 These entries are excluded regardless of verdict or `suppress` block.
 If the scanner still reports one, the resolution is incomplete and should be fixed rather than suppressed.
 
+Expired suppressions are always dropped::
+A `suppress` block whose `expires_at` date has passed is excluded, regardless of verdict.
+Expiry takes precedence over every other rule, so even a `not affected` finding is removed once its `expires_at` lapses.
+A finding without a `suppress` block has no expiry and stays suppressed.
+
 `not affected` findings are always suppressed::
-The finding does not impact the release, so it is noise and is suppressed automatically -- no `suppress` block required.
+The finding does not impact the release, so it is noise and is suppressed automatically; no `suppress` block is required.
+The one exception is the expiry rule above: if a `suppress` block is present and its `expires_at` has passed, the entry is dropped.
 
 Everything else needs an explicit `suppress` block::
 `affected`, `risk acceptable`, and not-yet-triaged findings are still a live or unknown risk.
@@ -55,7 +61,8 @@ reports:
       expires_at: 2026-06-01
 ----
 
-After the expiration date, the entry is excluded from the generated suppression file.
+After the expiration date, the entry is excluded from every generated suppression file.
+Vulnlog manages expiry itself so that each generated file lists only active suppressions and never an expired one.
 
 == Multiple Reporters
 

--- a/docs/modules/ROOT/pages/vulnerabilities.adoc
+++ b/docs/modules/ROOT/pages/vulnerabilities.adoc
@@ -184,7 +184,7 @@ A record indicating that a specific scanner or source reported the finding.
 | `expires_at`
 | String (date, `YYYY-MM-DD`)
 | No
-| Expiration date. After this date, the entry is excluded from the generated suppression file. When omitted, the suppression is permanent.
+| Expiration date. After this date, the entry is excluded from every generated suppression file. When omitted, the suppression is permanent.
 |===
 
 [[resolution-entry]]

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
@@ -36,7 +36,6 @@ fun collectSuppressedVulnerabilities(
         .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today) }
         .applyFilter(filter)
         .groupBy { it.reporter }
-        .filter { filter.filter.reporter == null || it.key == filter.filter.reporter }
 
 private fun isResolved(
     vulnEntry: VulnerabilityEntry,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Suppression.kt
@@ -4,6 +4,7 @@
 package dev.vulnlog.lib.core
 
 import dev.vulnlog.lib.model.Release
+import dev.vulnlog.lib.model.ReportEntry
 import dev.vulnlog.lib.model.ReporterType
 import dev.vulnlog.lib.model.Verdict
 import dev.vulnlog.lib.model.VulnerabilityEntry
@@ -15,7 +16,6 @@ import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
 import dev.vulnlog.lib.model.suppress.Suppression
 import dev.vulnlog.lib.model.suppress.SuppressionOutput
 import dev.vulnlog.lib.model.suppress.SuppressionVuln
-import java.time.LocalDate
 
 /**
  * Collects and filters suppressed vulnerabilities from a given Vulnlog file based on the specified suppression
@@ -33,7 +33,7 @@ fun collectSuppressedVulnerabilities(
     vulnlogFile.vulnerabilities
         .asSequence()
         .filterNot { vulnerability -> isResolved(vulnerability, filter.filter.releases) }
-        .flatMap { explodeAndMapToSuppressedVulnerabilities(it, filter.today) }
+        .flatMap(::explodeOnReports)
         .applyFilter(filter)
         .groupBy { it.reporter }
 
@@ -42,35 +42,26 @@ private fun isResolved(
     filterReleases: Set<Release>,
 ): Boolean = findWorkState(vulnEntry, filterReleases) == WorkState.RESOLVED
 
-private fun explodeAndMapToSuppressedVulnerabilities(
-    vulnerability: VulnerabilityEntry,
-    today: LocalDate,
-): List<SuppressedVulnerability> =
+private fun explodeOnReports(vulnerability: VulnerabilityEntry): List<SuppressedVulnerability> =
     vulnerability.reports
-        .filter { report -> isReportEligible(vulnerability.verdict, report.suppress, today) }
-        .flatMap { report ->
-            val ids = report.vulnIds.ifEmpty { setOf(vulnerability.id) }
-            ids.map { id ->
-                SuppressedVulnerability(
-                    id = id,
-                    releases = vulnerability.releases,
-                    reporter = report.reporter,
-                    expiresAt = report.suppress?.expiresAt,
-                    tags = vulnerability.tags,
-                    analysis = vulnerability.analysis ?: "",
-                )
-            }
-        }
+        .filter { report -> report.suppress != null || vulnerability.verdict is Verdict.NotAffected }
+        .flatMap { report -> explodeOnVulnIds(report, vulnerability) }
 
-private fun isReportEligible(
-    verdict: Verdict,
-    suppress: dev.vulnlog.lib.model.Suppression?,
-    today: LocalDate,
-): Boolean {
-    if (verdict is Verdict.NotAffected) return true
-    if (suppress == null) return false
-    val expiresAt = suppress.expiresAt ?: return true
-    return !expiresAt.isBefore(today)
+private fun explodeOnVulnIds(
+    report: ReportEntry,
+    vulnerability: VulnerabilityEntry,
+): List<SuppressedVulnerability> {
+    val vulnIds = report.vulnIds.ifEmpty { setOf(vulnerability.id) }
+    return vulnIds.map { id ->
+        SuppressedVulnerability(
+            id = id,
+            releases = vulnerability.releases,
+            reporter = report.reporter,
+            expiresAt = report.suppress?.expiresAt,
+            tags = vulnerability.tags,
+            analysis = vulnerability.analysis ?: "",
+        )
+    }
 }
 
 /**

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/VulnlogFilter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/VulnlogFilter.kt
@@ -31,3 +31,4 @@ fun Sequence<SuppressedVulnerability>.applyFilter(filter: SuppressionFilter): Se
         .filter { filter.filter.releases.isEmpty() || it.releases.any { release -> release in filter.filter.releases } }
         .filter { filter.filter.tags.isEmpty() || filter.filter.tags.any { tag -> it.tags.contains(tag) } }
         .filter { filter.filter.reporter == null || filter.filter.reporter == it.reporter }
+        .filter { it.isActiveOn(filter.today) }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/VulnlogFilter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/VulnlogFilter.kt
@@ -9,7 +9,6 @@ import dev.vulnlog.lib.model.Tag
 import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
 import java.time.LocalDate
-import kotlin.sequences.filter
 
 data class VulnlogFilter(
     val releases: Set<Release> = emptySet(),
@@ -31,3 +30,4 @@ fun Sequence<SuppressedVulnerability>.applyFilter(filter: SuppressionFilter): Se
     this
         .filter { filter.filter.releases.isEmpty() || it.releases.any { release -> release in filter.filter.releases } }
         .filter { filter.filter.tags.isEmpty() || filter.filter.tags.any { tag -> it.tags.contains(tag) } }
+        .filter { filter.filter.reporter == null || filter.filter.reporter == it.reporter }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/SuppressedVulnerability.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/SuppressedVulnerability.kt
@@ -16,7 +16,9 @@ data class SuppressedVulnerability(
     val expiresAt: LocalDate?,
     val tags: List<Tag> = emptyList(),
     val analysis: String,
-)
+) {
+    fun isActiveOn(date: LocalDate): Boolean = expiresAt == null || !date.isAfter(expiresAt)
+}
 
 sealed interface SuppressionOutput {
     data class GenericSuppression(

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionTest.kt
@@ -42,10 +42,20 @@ private fun emptyFile() =
         vulnerabilities = emptyList(),
     )
 
-private fun trivyReport(
+private fun report(
+    reporter: ReporterType,
     vulnIds: Set<VulnId> = emptySet(),
     suppress: Suppression? = Suppression(),
 ) = ReportEntry(
+    reporter = reporter,
+    vulnIds = vulnIds,
+    suppress = suppress,
+)
+
+private fun trivyReport(
+    vulnIds: Set<VulnId> = emptySet(),
+    suppress: Suppression? = Suppression(),
+) = report(
     reporter = ReporterType.TRIVY,
     vulnIds = vulnIds,
     suppress = suppress,
@@ -247,26 +257,30 @@ class SuppressionTest :
                 result shouldHaveSize 1
             }
 
-            test("excludes suppression expired before today") {
-                val report = trivyReport(suppress = Suppression(expiresAt = today.minusDays(1)))
-                val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
-                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+            ReporterType.entries.forEach { reporter ->
+                test("excludes suppression expired before today for $reporter") {
+                    val report = report(reporter = reporter, suppress = Suppression(expiresAt = today.minusDays(1)))
+                    val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
+                    val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    val result =
+                        collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result.shouldBeEmpty()
+                    result.shouldBeEmpty()
+                }
             }
 
-            test("includes suppression expiring after today") {
-                val report = trivyReport(suppress = Suppression(expiresAt = today.plusDays(30)))
-                val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
-                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+            ReporterType.entries.forEach { reporter ->
+                test("includes suppression expiring after today for $reporter") {
+                    val report = report(reporter = reporter, suppress = Suppression(expiresAt = today.plusDays(30)))
+                    val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
+                    val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    val result =
+                        collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result shouldHaveSize 1
+                    result shouldHaveSize 1
+                }
             }
 
             test("filters by reporter type") {
@@ -608,7 +622,7 @@ class SuppressionTest :
                 result shouldHaveSize 1
             }
 
-            test("not affected ignores suppress expiration") {
+            test("not affected respects suppress expiration") {
                 val report = trivyReport(suppress = Suppression(expiresAt = today.minusDays(30)))
                 val vuln =
                     vulnerability(
@@ -619,7 +633,7 @@ class SuppressionTest :
 
                 val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
 
-                result shouldHaveSize 1
+                result shouldHaveSize 0
             }
         }
 

--- a/schema/v1/defs/report.json
+++ b/schema/v1/defs/report.json
@@ -64,7 +64,7 @@
   "additionalProperties": false,
   "$defs": {
     "suppressEntry": {
-      "description": "Scanner-specific suppression configuration. Required to suppress findings with verdict 'affected' (without resolution), 'risk acceptable', or absent verdict. Not required for 'not affected' findings (always included in suppression output) or 'affected' findings with a 'resolution' (never included). When present without 'expires_at', the suppression is permanent",
+      "description": "Scanner-specific suppression configuration. Required to suppress findings with verdict 'affected' (without resolution), 'risk acceptable', or absent verdict. Not required for 'not affected' findings (included in suppression output unless a present 'expires_at' has passed) or 'affected' findings with a 'resolution' (never included). When present without 'expires_at', the suppression is permanent",
       "examples": [
         {},
         {
@@ -74,7 +74,7 @@
       "type": "object",
       "properties": {
         "expires_at": {
-          "description": "Expiration date of the suppression. After this date, the entry is excluded from the generated suppression file. Omit for permanent suppression",
+          "description": "Expiration date of the suppression. After this date, the entry is excluded from every generated suppression file, regardless of verdict. Omit for permanent suppression",
           "$ref": "common.json#/$defs/date"
         }
       },

--- a/schema/vulnlog-v1.json
+++ b/schema/vulnlog-v1.json
@@ -424,7 +424,7 @@
       "additionalProperties": false,
       "$defs": {
         "suppressEntry": {
-          "description": "Scanner-specific suppression configuration. Required to suppress findings with verdict 'affected' (without resolution), 'risk acceptable', or absent verdict. Not required for 'not affected' findings (always included in suppression output) or 'affected' findings with a 'resolution' (never included). When present without 'expires_at', the suppression is permanent",
+          "description": "Scanner-specific suppression configuration. Required to suppress findings with verdict 'affected' (without resolution), 'risk acceptable', or absent verdict. Not required for 'not affected' findings (included in suppression output unless a present 'expires_at' has passed) or 'affected' findings with a 'resolution' (never included). When present without 'expires_at', the suppression is permanent",
           "examples": [
             {},
             {
@@ -434,7 +434,7 @@
           "type": "object",
           "properties": {
             "expires_at": {
-              "description": "Expiration date of the suppression. After this date, the entry is excluded from the generated suppression file. Omit for permanent suppression",
+              "description": "Expiration date of the suppression. After this date, the entry is excluded from every generated suppression file, regardless of verdict. Omit for permanent suppression",
               "$ref": "#/$defs/https:~1~1vulnlog.dev~1schemas~1v1~1defs~1common.json/$defs/date"
             }
           },


### PR DESCRIPTION
One of Vulnlog's strengths is its ability to dynamically generate suppression files. Therefore, expired suppressions should not be included in the output format.

Fixes #169