### PR TITLE
fix: show duplicate ids by value

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Validator.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Validator.kt
@@ -98,7 +98,7 @@ private fun validateUniqueReleases(file: VulnlogFile): List<ValidationFinding> =
                 severity = Severity.ERROR,
                 rule = Rule.DUPLICATE_RELEASE_ID,
                 path = "releases[${id.value}]",
-                message = "Duplicate release ID '$id'.",
+                message = "Duplicate release ID '${id.value}'.",
             )
         }
 
@@ -111,7 +111,7 @@ private fun validateUniqueTags(file: VulnlogFile): List<ValidationFinding> =
                 severity = Severity.ERROR,
                 rule = Rule.DUPLICATE_TAG_ID,
                 path = "tags[${id.value}]",
-                message = "Duplicate tag ID '$id'.",
+                message = "Duplicate tag ID '${id.value}'.",
             )
         }
 

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ValidatorTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ValidatorTest.kt
@@ -74,6 +74,7 @@ class ValidatorTest :
                 errors[0].rule shouldBe Rule.DUPLICATE_RELEASE_ID
                 errors[0].severity shouldBe Severity.ERROR
                 errors[0].path shouldBe "releases[v1.0]"
+                errors[0].message shouldBe "Duplicate release ID 'v1.0'."
             }
         }
 
@@ -100,6 +101,7 @@ class ValidatorTest :
                 errors shouldHaveSize 1
                 errors[0].rule shouldBe Rule.DUPLICATE_TAG_ID
                 errors[0].path shouldBe "tags[backend]"
+                errors[0].message shouldBe "Duplicate tag ID 'backend'."
             }
         }
 


### PR DESCRIPTION
## Summary
- render duplicate release and tag IDs with their raw values instead of Kotlin data-class `toString()` output
- add validator coverage for duplicate release/tag message text

## Verification
- `./gradlew :lib:test --tests 'dev.vulnlog.lib.core.ValidatorTest'`\n- `./gradlew :lib:check`\n- `git diff --check`\n\nCloses #203.