### PR TITLE
docs: Add support and help resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or help
+    url: https://github.com/vulnlog/vulnlog/discussions/categories/q-a
+    about: Ask how to use Vulnlog, including the .vl.yaml format, suppression output, and CLI usage.

--- a/README.md
+++ b/README.md
@@ -154,8 +154,13 @@ vulnlog report vulnlog.yaml
 - [Documentation](https://vulnlog.dev/docs/)
 - [Project Website](https://vulnlog.dev/)
 - [Changelog](CHANGELOG.md)
+- [Get help](SUPPORT.md)
 
 ## Community
+
+Have a question or an idea? Join the conversation in
+[GitHub Discussions](https://github.com/vulnlog/vulnlog/discussions): ask in Q&A, propose features,
+or share how you use Vulnlog.
 
 [![Bluesky](https://img.shields.io/bluesky/followers/vulnlog.bsky.social?style=flat&logo=bluesky&labelColor=white&color=blue)](https://bsky.app/profile/vulnlog.bsky.social)
 [![Mastodon](https://img.shields.io/mastodon/follow/114149693629631038?domain=infosec.exchange&style=flat&logo=mastodon&labelColor=white&color=blue)](https://infosec.exchange/@vulnlog)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,40 @@
+# Support
+
+Thanks for using Vulnlog! Here is where to get help.
+
+## Ask a question
+
+For how-to questions about using Vulnlog, the YAML format, suppression output, or the CLI, start a
+thread in GitHub Discussions:
+
+- [Ask in Discussions (Q&A)](https://github.com/vulnlog/vulnlog/discussions/categories/q-a)
+
+To get a useful answer quickly, please include:
+
+- The Vulnlog version (`vulnlog --version`) and your platform.
+- The scanner you generate suppressions for (for example Trivy or Snyk), if relevant.
+- A minimal `*.vl.yaml` snippet and the exact command you ran.
+- The full output or error message.
+
+## Report a bug
+
+If something is broken or behaves unexpectedly, open a
+[bug report](https://github.com/vulnlog/vulnlog/issues/new?template=BugReportTemplate.md).
+
+## Request a feature
+
+Have an idea for a new feature? Open a
+[feature request](https://github.com/vulnlog/vulnlog/issues/new?template=FeatureRequestTemplate.md),
+or float the idea first in
+[Discussions](https://github.com/vulnlog/vulnlog/discussions).
+
+## Report a security issue
+
+Please do not open a public issue for security problems. Follow the process in
+[SECURITY.md](SECURITY.md) to report privately.
+
+## Documentation
+
+- [User documentation](https://vulnlog.dev/docs/)
+- [Project website](https://vulnlog.dev/)
+- [Contributing guide](CONTRIBUTING.md)

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -28,3 +28,4 @@
 ** xref:gradle-plugin.adoc[Gradle Plugin]
 ** xref:migration-guide.adoc[Migration from Kotlin DSL]
 * xref:glossary.adoc[Glossary]
+* https://github.com/vulnlog/vulnlog/discussions[Get help]

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
@@ -31,6 +31,13 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.writeText
 
+private const val HELP_DISCUSSIONS_URL = "https://github.com/vulnlog/vulnlog/discussions/categories/q-a"
+
+fun CliktCommand.echoHelpHint() {
+    echo("", err = true)
+    echo("Stuck? Ask for help at $HELP_DISCUSSIONS_URL", err = true)
+}
+
 fun CliktCommand.parseInputOrFail(inputs: List<FileInputOption>): Map<FileInputOption, ParseResult.Ok> {
     val parseResults: ParseResults =
         try {
@@ -42,6 +49,7 @@ fun CliktCommand.parseInputOrFail(inputs: List<FileInputOption>): Map<FileInputO
         }
     if (parseResults.failure.isNotEmpty()) {
         renderParseFailures(parseResults).forEach { echo(it, err = true) }
+        echoHelpHint()
         throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)
     }
     return parseResults.success
@@ -57,6 +65,7 @@ fun CliktCommand.validateParsedInputOrFailWithFailureOutput(
         echo(rendered, err = true)
     }
     if (validationFindings.hasErrors) {
+        echoHelpHint()
         throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)
     }
     return validationFindings

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
@@ -4,6 +4,7 @@
 package dev.vulnlog.cli.shell
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.versionOption
@@ -23,6 +24,9 @@ class VulnlogCli : CliktCommand(name = "vulnlog") {
     init {
         versionOption(BuildInfo.VERSION)
     }
+
+    override fun helpEpilog(context: Context): String =
+        "Questions or feedback? Join the discussion at https://github.com/vulnlog/vulnlog/discussions"
 
     override fun run() = Unit
 }


### PR DESCRIPTION
- Introduced GitHub Discussions links in `README.md`, CLI, and docs navigation for questions and feedback.
- Added a `SUPPORT.md` file to centralize help, bug reporting, and feature request guidance.
- Included help hints and discussion links in CLI error messages for better user direction.