### PR TITLE
fix: correct analysis schema description

### DIFF
--- a/schema/v1/defs/vulnerability.json
+++ b/schema/v1/defs/vulnerability.json
@@ -162,7 +162,7 @@
       }
     },
     "analysis": {
-      "description": "Free-text analysis and rationale for the triage decision. Presence of this field moves the entry out of the 'under investigation' state",
+      "description": "Free-text analysis and rationale for the triage decision. The state is derived from 'verdict' and 'resolution', not from this field",
       "examples": [
         "The affected StreamReadConstraints class is not used in the application."
       ],

--- a/schema/vulnlog-v1.json
+++ b/schema/vulnlog-v1.json
@@ -605,7 +605,7 @@
           }
         },
         "analysis": {
-          "description": "Free-text analysis and rationale for the triage decision. Presence of this field moves the entry out of the 'under investigation' state",
+          "description": "Free-text analysis and rationale for the triage decision. The state is derived from 'verdict' and 'resolution', not from this field",
           "examples": [
             "The affected StreamReadConstraints class is not used in the application."
           ],


### PR DESCRIPTION
Fixes #206.

Updates the `analysis` field description in both schema files so it no longer says the field changes the vulnerability state.

Checked:
- python3 -m json.tool schema/v1/defs/vulnerability.json
- python3 -m json.tool schema/vulnlog-v1.json