### PR TITLE
fix: use canonical names for generic suppressions

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionOutputs.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionOutputs.kt
@@ -75,7 +75,7 @@ private fun createGenericSuppression(
                 )
             }.toSet()
     return SuppressionOutput.GenericSuppression(
-        fileName = format.reporter.name.lowercase() + ".generic.json",
+        fileName = format.reporter.canonical() + ".generic.json",
         entries = entries,
     )
 }

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionOutputsTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionOutputsTest.kt
@@ -213,6 +213,18 @@ class SuppressionOutputsTest :
                 generic.fileName shouldBe "grype.generic.json"
             }
 
+            test("generic filenames use canonical reporter names") {
+                val result =
+                    buildSuppressionOutputs(
+                        setOf(ReporterType.GITHUB_DEPENDABOT),
+                        emptyMap(),
+                        SuppressionFormatRequest.Generic,
+                    )
+
+                val generic = result.first().shouldBeInstanceOf<SuppressionOutput.GenericSuppression>()
+                generic.fileName shouldBe "github-dependabot.generic.json"
+            }
+
             test("generic overrides the native format of a native reporter") {
                 val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-1234"), analysis = "false positive")
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))


### PR DESCRIPTION
Fixes #204.

Generic suppression filenames now use the reporter canonical name, so names like `github-dependabot.generic.json` match the CLI/docs spelling.

I added a test for the hyphenated reporter name. I could not run the Gradle test locally because this machine has no Java runtime available.