### PR TITLE
fix: validate resolution release references

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Validator.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Validator.kt
@@ -168,18 +168,36 @@ private fun validateAliasNotReferencedInAliasIds(file: VulnlogFile): List<Valida
 private fun validateVulnerabilitiesReferenceValidReleases(file: VulnlogFile): List<ValidationFinding> {
     val definedIds = file.releases.map { it.id }.toSet()
     return file.vulnerabilities.flatMap { vuln ->
-        vuln.releases
-            .filter { it !in definedIds }
-            .map { ref ->
-                ValidationFinding(
-                    severity = Severity.ERROR,
-                    rule = Rule.DANGLING_RELEASE_REFERENCE,
-                    path = "vulnerabilities[${vuln.id.canonical()}].releases",
-                    message = "References undefined release '${ref.value}'. Defined releases: ${
-                        definedIds.sortedBy { it.value }.joinToString { it.value }
-                    }",
-                )
-            }
+        val releaseFindings =
+            vuln.releases
+                .filter { it !in definedIds }
+                .map { ref ->
+                    ValidationFinding(
+                        severity = Severity.ERROR,
+                        rule = Rule.DANGLING_RELEASE_REFERENCE,
+                        path = "vulnerabilities[${vuln.id.canonical()}].releases",
+                        message = "References undefined release '${ref.value}'. Defined releases: ${
+                            definedIds.sortedBy { it.value }.joinToString { it.value }
+                        }",
+                    )
+                }
+
+        val resolutionFinding =
+            vuln.resolution
+                ?.release
+                ?.takeIf { it !in definedIds }
+                ?.let { ref ->
+                    ValidationFinding(
+                        severity = Severity.ERROR,
+                        rule = Rule.DANGLING_RELEASE_REFERENCE,
+                        path = "vulnerabilities[${vuln.id.canonical()}].resolution",
+                        message = "References undefined release '${ref.value}'. Defined releases: ${
+                            definedIds.sortedBy { it.value }.joinToString { it.value }
+                        }",
+                    )
+                }
+
+        releaseFindings + listOfNotNull(resolutionFinding)
     }
 }
 

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ValidatorTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ValidatorTest.kt
@@ -11,6 +11,7 @@ import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReleaseEntry
 import dev.vulnlog.lib.model.ReportEntry
 import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.Resolution
 import dev.vulnlog.lib.model.SchemaVersion
 import dev.vulnlog.lib.model.Tag
 import dev.vulnlog.lib.model.TagEntry
@@ -206,6 +207,29 @@ class ValidatorTest :
                 val errors = validate(context(file)).errors
                 errors[0].message shouldContain "v1.0"
                 errors[0].message shouldContain "v1.1"
+            }
+
+            test("resolution referencing undefined release produces an error") {
+                val file =
+                    emptyFile().copy(
+                        releases = listOf(ReleaseEntry(Release("v1.0"))),
+                        vulnerabilities =
+                            listOf(
+                                VulnerabilityEntry(
+                                    id = VulnId.Cve("CVE-2021-1"),
+                                    releases = emptyList(),
+                                    packages = emptyList(),
+                                    reports = emptyList(),
+                                    resolution = Resolution(Release("v2.0")),
+                                    verdict = Verdict.UnderInvestigation,
+                                ),
+                            ),
+                    )
+                val errors = validate(context(file)).errors
+                errors shouldHaveSize 1
+                errors[0].rule shouldBe Rule.DANGLING_RELEASE_REFERENCE
+                errors[0].path shouldBe "vulnerabilities[CVE-2021-1].resolution"
+                errors[0].message shouldContain "v2.0"
             }
         }
 


### PR DESCRIPTION
Fixes #194.

This checks `resolution.in` against the top-level releases list, so a typo there fails the same way as a bad vulnerability `releases` entry.

I added a validator test for the missing resolution release case. I could not run the Gradle test locally because this machine has no Java runtime available.