### PR TITLE
fix: allow under_investigation in schema verdicts

### DIFF
--- a/schema/v1/defs/common.json
+++ b/schema/v1/defs/common.json
@@ -24,7 +24,7 @@
       "pattern": "^pkg:[a-zA-Z][a-zA-Z0-9.+-]*/"
     },
     "verdict": {
-      "description": "The human triage decision for a vulnerability. Absence or 'under_investigation' indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
+      "description": "The human triage decision for a vulnerability. Absence or 'under investigation' indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
       "oneOf": [
         {
           "description": "The vulnerability impacts this release and remediation is expected. Requires 'severity'",
@@ -40,7 +40,7 @@
         },
         {
           "description": "The vulnerability is still being investigated",
-          "const": "under_investigation"
+          "const": "under investigation"
         }
       ]
     },

--- a/schema/v1/defs/common.json
+++ b/schema/v1/defs/common.json
@@ -24,7 +24,7 @@
       "pattern": "^pkg:[a-zA-Z][a-zA-Z0-9.+-]*/"
     },
     "verdict": {
-      "description": "The human triage decision for a vulnerability. Absence indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
+      "description": "The human triage decision for a vulnerability. Absence or 'under_investigation' indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
       "oneOf": [
         {
           "description": "The vulnerability impacts this release and remediation is expected. Requires 'severity'",
@@ -37,6 +37,10 @@
         {
           "description": "The vulnerability impacts this release but the risk has been assessed and accepted without remediation. Requires 'severity' and an explicit 'suppress' block to suppress the finding",
           "const": "risk acceptable"
+        },
+        {
+          "description": "The vulnerability is still being investigated",
+          "const": "under_investigation"
         }
       ]
     },

--- a/schema/vulnlog-v1.json
+++ b/schema/vulnlog-v1.json
@@ -153,7 +153,7 @@
           "pattern": "^pkg:[a-zA-Z][a-zA-Z0-9.+-]*/"
         },
         "verdict": {
-          "description": "The human triage decision for a vulnerability. Absence or 'under_investigation' indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
+          "description": "The human triage decision for a vulnerability. Absence or 'under investigation' indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
           "oneOf": [
             {
               "description": "The vulnerability impacts this release and remediation is expected. Requires 'severity'",
@@ -169,7 +169,7 @@
             },
             {
               "description": "The vulnerability is still being investigated",
-              "const": "under_investigation"
+              "const": "under investigation"
             }
           ]
         },

--- a/schema/vulnlog-v1.json
+++ b/schema/vulnlog-v1.json
@@ -153,7 +153,7 @@
           "pattern": "^pkg:[a-zA-Z][a-zA-Z0-9.+-]*/"
         },
         "verdict": {
-          "description": "The human triage decision for a vulnerability. Absence indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
+          "description": "The human triage decision for a vulnerability. Absence or 'under_investigation' indicates the vulnerability is under investigation. 'affected' and 'risk acceptable' require a severity; 'not affected' requires a justification",
           "oneOf": [
             {
               "description": "The vulnerability impacts this release and remediation is expected. Requires 'severity'",
@@ -166,6 +166,10 @@
             {
               "description": "The vulnerability impacts this release but the risk has been assessed and accepted without remediation. Requires 'severity' and an explicit 'suppress' block to suppress the finding",
               "const": "risk acceptable"
+            },
+            {
+              "description": "The vulnerability is still being investigated",
+              "const": "under_investigation"
             }
           ]
         },


### PR DESCRIPTION
Fixes #205.

The CLI already accepts `verdict: under_investigation`, so this adds the same value to both v1 schema files and updates the verdict description.

Checked both JSON files with `python3 -m json.tool`.