### PR TITLE
fix: write Trivy expired_at suppression key

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/trivy/dto/TrivyVulnerabilityEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/trivy/dto/TrivyVulnerabilityEntryDto.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 
 data class TrivyVulnerabilityEntryDto(
     val id: String,
-    @param:JsonProperty("expires_at")
+    @param:JsonProperty("expired_at")
     @param:JsonFormat(pattern = "yyyy-MM-dd")
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val expiredAt: LocalDate? = null,

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/trivy/TrivySuppressionWriterTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/trivy/TrivySuppressionWriterTest.kt
@@ -1,0 +1,35 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.suppression.trivy
+
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.model.suppress.SuppressionVuln
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.time.LocalDate
+
+class TrivySuppressionWriterTest :
+    FunSpec({
+
+        test("writes Trivy expiration key as expired_at") {
+            val input =
+                SuppressionOutput.TrivySuppression(
+                    entries =
+                        setOf(
+                            SuppressionVuln.TrivySuppressionEntry(
+                                id = VulnId.Cve("CVE-2026-1111"),
+                                expiresAt = LocalDate.of(2026, 8, 1),
+                                reason = "temp suppression while fix pending",
+                            ),
+                        ),
+                )
+
+            val result = TrivySuppressionWriter.write(input)
+
+            result shouldContain "expired_at: 2026-08-01"
+            result shouldNotContain "expires_at"
+        }
+    })


### PR DESCRIPTION
Fixes #188.

Trivy expects `expired_at` in `.trivyignore.yaml`, so this changes only the Trivy output DTO. The Vulnlog input schema still keeps its own `expires_at` field.

I added a writer test for the emitted key. I could not run the Gradle test locally because this machine has no Java runtime available.