### PR TITLE
fix: write Snyk expiry date-time format

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapper.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapper.kt
@@ -6,6 +6,7 @@ package dev.vulnlog.lib.parse.suppression.snyk
 import dev.vulnlog.lib.model.suppress.SuppressionOutput
 import dev.vulnlog.lib.parse.suppression.snyk.dto.SnykIgnoreEntryDto
 import dev.vulnlog.lib.parse.suppression.snyk.dto.SnykSuppressionDto
+import java.time.LocalDate
 
 object SnykMapper {
     fun toDto(suppressionData: SuppressionOutput.SnykSuppression): SnykSuppressionDto {
@@ -17,11 +18,13 @@ object SnykMapper {
                             "*" to
                                 SnykIgnoreEntryDto(
                                     reason = entry.reason,
-                                    expires = entry.expiresAt,
+                                    expires = entry.expiresAt?.toSnykExpires(),
                                 ),
                         ),
                     )
             }
-        return SnykSuppressionDto(ignore)
+        return SnykSuppressionDto(ignore = ignore)
     }
+
+    private fun LocalDate.toSnykExpires(): String = "${this}T00:00:00.000Z"
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapper.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapper.kt
@@ -6,7 +6,6 @@ package dev.vulnlog.lib.parse.suppression.snyk
 import dev.vulnlog.lib.model.suppress.SuppressionOutput
 import dev.vulnlog.lib.parse.suppression.snyk.dto.SnykIgnoreEntryDto
 import dev.vulnlog.lib.parse.suppression.snyk.dto.SnykSuppressionDto
-import java.time.LocalDate
 
 object SnykMapper {
     fun toDto(suppressionData: SuppressionOutput.SnykSuppression): SnykSuppressionDto {
@@ -18,13 +17,11 @@ object SnykMapper {
                             "*" to
                                 SnykIgnoreEntryDto(
                                     reason = entry.reason,
-                                    expires = entry.expiresAt?.toSnykExpires(),
+                                    expires = entry.expiresAt?.atStartOfDay(),
                                 ),
                         ),
                     )
             }
         return SnykSuppressionDto(ignore = ignore)
     }
-
-    private fun LocalDate.toSnykExpires(): String = "${this}T00:00:00.000Z"
 }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/dto/SnykIgnoreEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/dto/SnykIgnoreEntryDto.kt
@@ -3,14 +3,11 @@
 
 package dev.vulnlog.lib.parse.suppression.snyk.dto
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
-import java.time.LocalDate
 
 data class SnykIgnoreEntryDto(
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val reason: String? = null,
-    @param:JsonFormat(pattern = "yyyy-MM-dd")
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
-    val expires: LocalDate? = null,
+    val expires: String? = null,
 )

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/dto/SnykIgnoreEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/dto/SnykIgnoreEntryDto.kt
@@ -3,11 +3,14 @@
 
 package dev.vulnlog.lib.parse.suppression.snyk.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
+import java.time.LocalDateTime
 
 data class SnykIgnoreEntryDto(
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
     val reason: String? = null,
+    @param:JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     @param:JsonInclude(JsonInclude.Include.NON_NULL)
-    val expires: String? = null,
+    val expires: LocalDateTime? = null,
 )

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/dto/SnykSuppressionDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/suppression/snyk/dto/SnykSuppressionDto.kt
@@ -4,5 +4,6 @@
 package dev.vulnlog.lib.parse.suppression.snyk.dto
 
 data class SnykSuppressionDto(
+    val version: String = "v1.25.0",
     val ignore: Map<String, List<Map<String, SnykIgnoreEntryDto>>>,
 )

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapperTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapperTest.kt
@@ -35,7 +35,7 @@ class SnykMapperTest :
             entryList.size shouldBe 1
             val wildcardEntry = entryList.first()["*"]!!
             wildcardEntry.reason shouldBe "not exploitable"
-            wildcardEntry.expires shouldBe LocalDate.of(2026, 12, 31)
+            wildcardEntry.expires shouldBe "2026-12-31T00:00:00.000Z"
         }
 
         test("maps multiple entries to separate ignore keys") {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapperTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykMapperTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class SnykMapperTest :
     FunSpec({
@@ -35,7 +36,7 @@ class SnykMapperTest :
             entryList.size shouldBe 1
             val wildcardEntry = entryList.first()["*"]!!
             wildcardEntry.reason shouldBe "not exploitable"
-            wildcardEntry.expires shouldBe "2026-12-31T00:00:00.000Z"
+            wildcardEntry.expires shouldBe LocalDateTime.of(2026, 12, 31, 0, 0)
         }
 
         test("maps multiple entries to separate ignore keys") {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykSuppressionWriterTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/suppression/snyk/SnykSuppressionWriterTest.kt
@@ -1,0 +1,34 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.suppression.snyk
+
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.model.suppress.SuppressionVuln
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import java.time.LocalDate
+
+class SnykSuppressionWriterTest :
+    FunSpec({
+
+        test("writes Snyk policy version and date-time expires value") {
+            val input =
+                SuppressionOutput.SnykSuppression(
+                    entries =
+                        setOf(
+                            SuppressionVuln.SnykSuppressionEntry(
+                                id = VulnId.Snyk("SNYK-JS-EXAMPLE-1234567"),
+                                expiresAt = LocalDate.of(2026, 8, 1),
+                                reason = "temp suppression",
+                            ),
+                        ),
+                )
+
+            val result = SnykSuppressionWriter.write(input)
+
+            result shouldContain "version: v1.25.0"
+            result shouldContain "expires: 2026-08-01T00:00:00.000Z"
+        }
+    })


### PR DESCRIPTION
Fixes #189.

Snyk wants ignore expirations as `YYYY-MM-DDT00:00:00.000Z`, so this formats Vulnlog dates that way in the `.snyk` output. It also adds the documented policy `version` field.

I added mapper and writer coverage for the output. I could not run the Gradle tests locally because this machine has no Java runtime available.