### PR TITLE
fix: protect init output files

### DIFF
--- a/docs/modules/ROOT/pages/cli-init.adoc
+++ b/docs/modules/ROOT/pages/cli-init.adoc
@@ -14,6 +14,9 @@ vulnlog init [flags]
 | `-o, --output <path>`
 | Output path for the generated file. Defaults to stdout.
 
+| `--force`
+| Overwrite the output file if it already exists.
+
 | `--name <text>`
 | Project name. Prompted if not provided.
 

--- a/docs/modules/ROOT/pages/gradle-plugin.adoc
+++ b/docs/modules/ROOT/pages/gradle-plugin.adoc
@@ -63,6 +63,10 @@ See xref:cli-init.adoc[`vulnlog init`] for the generated structure.
 | `vulnlog.output`
 | Yes
 | Output file path, relative to the project directory.
+
+| `vulnlog.force`
+| No
+| Set to `true` to overwrite the output file if it already exists.
 |===
 
 .Example

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
@@ -133,7 +133,13 @@ fun writeInit(
     err: (String) -> Unit,
     initFile: FileOutputOption.File,
     content: String,
+    force: Boolean = false,
 ) {
+    if (initFile.path.exists() && !force) {
+        err("${initFile.path} already exists. Use --force to overwrite.")
+        throw ProgramResult(ExitCode.GENERAL_ERROR.ordinal)
+    }
+
     try {
         initFile.path.writeText(content)
         out("Vulnlog file created at: ${initFile.path.toAbsolutePath()}")

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/InitCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/InitCommand.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import dev.vulnlog.lib.core.init
@@ -36,6 +37,10 @@ class InitCommand : CliktCommand(name = "init") {
         help = "Output path for the generated file. Defaults to stdout. Use '-' for explicit stdout.",
     ).convert { toOutputFileOption(it) }
         .default(FileOutputOption.Stdout)
+    val force: Boolean by option(
+        "--force",
+        help = "Overwrite the output file if it already exists.",
+    ).flag(default = false)
 
     private val mapper = createYamlMapper()
 
@@ -51,6 +56,7 @@ class InitCommand : CliktCommand(name = "init") {
                     { echo(it, err = true) },
                     target,
                     content,
+                    force,
                 )
 
             is FileOutputOption.Stdout -> echo(content)

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/InitCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/InitCommandTest.kt
@@ -41,11 +41,31 @@ class InitCommandTest :
             }
 
             test("writes YAML to a file when -o path is specified") {
-                withTempFile(prefix = "vulnlog-init", suffix = ".yaml") { output ->
-                    val result = InitCommand().test("$REQUIRED_OPTIONS -o ${output.absolutePath}")
+                withTempDir(prefix = "vulnlog-init") { dir ->
+                    val output = dir.resolve("vulnlog.yaml")
+                    val result = InitCommand().test("$REQUIRED_OPTIONS -o $output")
 
                     result.statusCode shouldBe 0
                     result.stdout shouldContain "Vulnlog file created at:"
+                    output.toFile().readText() shouldContain "acme"
+                }
+            }
+
+            test("does not overwrite an existing output file without --force") {
+                withTempFile(prefix = "vulnlog-init", suffix = ".yaml", content = "keep me") { output ->
+                    val result = InitCommand().test("$REQUIRED_OPTIONS -o ${output.absolutePath}")
+
+                    result.statusCode shouldBe 1
+                    result.stderr shouldContain "already exists"
+                    output.readText() shouldBe "keep me"
+                }
+            }
+
+            test("overwrites an existing output file with --force") {
+                withTempFile(prefix = "vulnlog-init", suffix = ".yaml", content = "replace me") { output ->
+                    val result = InitCommand().test("$REQUIRED_OPTIONS -o ${output.absolutePath} --force")
+
+                    result.statusCode shouldBe 0
                     output.readText() shouldContain "acme"
                 }
             }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogInitTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogInitTask.kt
@@ -8,6 +8,7 @@ import dev.vulnlog.lib.model.SchemaVersion
 import dev.vulnlog.lib.parse.YamlWriter
 import dev.vulnlog.lib.parse.createYamlMapper
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
@@ -26,6 +27,9 @@ abstract class VulnlogInitTask : DefaultTask() {
     @get:Input
     abstract val author: Property<String>
 
+    @get:Input
+    abstract val force: Property<Boolean>
+
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
@@ -34,6 +38,9 @@ abstract class VulnlogInitTask : DefaultTask() {
         val vulnlogFile = init(SchemaVersion(1, 0), organization.get(), projectName.get(), author.get())
         val content = YamlWriter.write(vulnlogFile, createYamlMapper())
         val file = outputFile.get().asFile
+        if (file.exists() && !force.get()) {
+            throw GradleException("${file.absolutePath} already exists. Use -Pvulnlog.force=true to overwrite.")
+        }
         file.writeText(content)
         logger.lifecycle("Vulnlog file created at: ${file.absolutePath}")
     }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogPlugin.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogPlugin.kt
@@ -16,6 +16,12 @@ class VulnlogPlugin : Plugin<Project> {
             task.organization.convention(project.propertyOrNull("vulnlog.organization"))
             task.projectName.convention(project.propertyOrNull("vulnlog.name"))
             task.author.convention(project.propertyOrNull("vulnlog.author"))
+            task.force.convention(
+                project.providers
+                    .gradleProperty("vulnlog.force")
+                    .map { it.toBoolean() }
+                    .orElse(false),
+            )
             task.outputFile.convention(
                 project.propertyOrNull("vulnlog.output")?.let { project.layout.projectDirectory.file(it) },
             )

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogInitTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogInitTaskTest.kt
@@ -33,6 +33,25 @@ class VulnlogInitTaskTest :
                 content shouldContain "Alice"
                 content shouldContain "schemaVersion:"
             }
+
+            test("does not overwrite an existing output file without force") {
+                val dir = gradleProject(buildFile(), "vulnlog.yaml" to "keep me")
+
+                val result = runner(dir, "vulnlogInit", *REQUIRED_PROPS).buildAndFail()
+
+                result.task(":vulnlogInit")?.outcome shouldBe TaskOutcome.FAILED
+                result.output shouldContain "already exists"
+                dir.resolve("vulnlog.yaml").readText() shouldBe "keep me"
+            }
+
+            test("overwrites an existing output file with force") {
+                val dir = gradleProject(buildFile(), "vulnlog.yaml" to "replace me")
+
+                val result = runner(dir, "vulnlogInit", *REQUIRED_PROPS, "-Pvulnlog.force=true").build()
+
+                result.task(":vulnlogInit")?.outcome shouldBe TaskOutcome.SUCCESS
+                dir.resolve("vulnlog.yaml").readText() shouldContain "Acme Corp"
+            }
         }
 
         context("argument validation") {


### PR DESCRIPTION
Fixes #202.

`vulnlog init` and the Gradle `vulnlogInit` task now fail when the output file already exists. `--force` / `-Pvulnlog.force=true` keeps the old overwrite behavior when it is intentional.

I added CLI and Gradle task tests for both paths. I could not run them locally because this machine has no Java runtime available.