### PR TITLE
fix: copy into targets without releases

### DIFF
--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/CopyCommandTest.kt
@@ -49,6 +49,20 @@ private val SOURCE_YAML =
 
 private val TARGET_YAML = vulnlogYaml(releaseId = "1.0.0", cveId = "CVE-2026-0001")
 
+private val EMPTY_RELEASE_TARGET_YAML =
+    """
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases: []
+
+    vulnerabilities: []
+    """.trimIndent()
+
 class CopyCommandTest :
     FunSpec({
 
@@ -116,6 +130,23 @@ class CopyCommandTest :
                         )
 
                         target.readText() shouldContain "releases: [1.0.0]"
+                    }
+                }
+            }
+
+            test("copies with empty releases when the target has no releases") {
+                withTempFile(prefix = "source", content = SOURCE_YAML) { source ->
+                    withTempFile(prefix = "target", content = EMPTY_RELEASE_TARGET_YAML) { target ->
+                        val result =
+                            CopyCommand().test(
+                                "${source.absolutePath} ${target.absolutePath} --vuln-id CVE-2026-1234",
+                            )
+
+                        result.statusCode shouldBe 0
+                        val content = target.readText()
+                        content shouldContain "CVE-2026-1234"
+                        content shouldContain "releases: []"
+                        content shouldNotContain "2.0.0"
                     }
                 }
             }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Copy.kt
@@ -34,7 +34,8 @@ data class CopyOutcome(
  * If an entry already exists in the destination, it is merged with the source entry and keeps its
  * position: existing values win for scalars; lists (aliases, packages, tags) are unioned; reports are
  * unioned by reporter. New entries are placed at the top of the `vulnerabilities:` list. Releases on
- * every copied entry are rewritten to the destination's latest release.
+ * every copied entry are rewritten to the destination's latest release, or to an empty list when
+ * the destination has no releases yet.
  */
 fun copyVulnerabilities(
     source: VulnlogFile,
@@ -44,8 +45,8 @@ fun copyVulnerabilities(
 ): CopyOutcome {
     val release =
         destination.content.releases
-            .last()
-            .id
+            .lastOrNull()
+            ?.id
     val sourceEntries = source.vulnerabilities.filter { it.id in vulnIds }
     val existingById = destination.content.vulnerabilities.associateBy { it.id }
 
@@ -85,13 +86,14 @@ private fun upsertEntry(
 private fun mergeVulnerabilityEntry(
     existing: VulnerabilityEntry?,
     incoming: VulnerabilityEntry,
-    release: Release,
+    release: Release?,
 ): VulnerabilityEntry {
-    if (existing == null) return incoming.copy(releases = listOf(release))
+    val releases = release?.let(::listOf) ?: emptyList()
+    if (existing == null) return incoming.copy(releases = releases)
     return existing.copy(
         name = existing.name ?: incoming.name,
         aliases = unionPreservingOrder(existing.aliases, incoming.aliases),
-        releases = listOf(release),
+        releases = releases,
         description = existing.description ?: incoming.description,
         packages = unionPreservingOrder(existing.packages, incoming.packages),
         reports = mergeReports(existing.reports, incoming.reports),


### PR DESCRIPTION
Fixes #196.

When the target file has no releases yet, `modify copy` now keeps the copied entry with an empty `releases` list instead of calling `last()` and crashing. This matches the way `modify add` handles a target without releases.

I added a CLI regression test. I could not run it locally because this machine has no Java runtime available.