### PR TITLE
fix: escape report data in inline scripts

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/HtmlReportWriter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/HtmlReportWriter.kt
@@ -18,7 +18,7 @@ object HtmlReportWriter {
      */
     fun renderHtmlReport(reportDataDto: ReportDataDto): String {
         val template = loadTemplate()
-        val json = serializeToJson(reportDataDto)
+        val json = serializeToJson(reportDataDto).escapeForInlineScript()
         return template.replace(DATA_PLACEHOLDER, json)
     }
 
@@ -38,4 +38,9 @@ object HtmlReportWriter {
                 .build()
         return mapper.writeValueAsString(data)
     }
+
+    private fun String.escapeForInlineScript(): String =
+        replace("&", "\\u0026")
+            .replace("<", "\\u003c")
+            .replace(">", "\\u003e")
 }

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportRendererTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportRendererTest.kt
@@ -85,6 +85,13 @@ class HtmlReportRendererTest :
             html shouldNotContain "VULNLOG_DATA_PLACEHOLDER"
         }
 
+        test("escapes script-breaking characters in serialized data") {
+            val html = render(listOf(entry(description = "breaks </script> & report")))
+
+            html shouldNotContain "breaks </script> & report"
+            html shouldContain "breaks \\u003c/script\\u003e \\u0026 report"
+        }
+
         test("renders with empty entries") {
             val html = render(emptyList())
 


### PR DESCRIPTION
Fixes #197.

The report JSON is now escaped before it is injected into the inline script, so text like `</script>` stays data and cannot break the page.

I added a renderer regression for the script-breaking characters. I could not run the Gradle test locally because this machine has no Java runtime available.