### PR TITLE
fix: Keep vulnerability names in reports

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
@@ -42,6 +42,7 @@ fun collectReportingEntries(
             ReportingEntry(
                 state = findWorkState(vuln, filter.releases),
                 primaryId = vuln.id,
+                name = vuln.name,
                 ids = vuln.aliases.toSet(),
                 shortDescription = vuln.description,
                 impact = defineImpact(vuln),
@@ -78,6 +79,7 @@ private fun mergeTwo(
     b: ReportingEntry,
 ): ReportingEntry =
     a.copy(
+        name = a.name ?: b.name,
         ids = a.ids + b.ids,
         shortDescription = a.shortDescription ?: b.shortDescription,
         reportFor = a.reportFor + b.reportFor,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/report/ReportingEntry.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/report/ReportingEntry.kt
@@ -9,6 +9,7 @@ import dev.vulnlog.lib.model.VulnId
 data class ReportingEntry(
     val state: WorkState,
     val primaryId: VulnId,
+    val name: String? = null,
     val ids: Set<VulnId>,
     val shortDescription: String?,
     val impact: Impact,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/HtmlReportMapper.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/HtmlReportMapper.kt
@@ -45,6 +45,7 @@ object HtmlReportMapper {
     private fun toReportEntryData(entry: ReportingEntry): ReportEntryDataDto =
         ReportEntryDataDto(
             primaryId = entry.primaryId.id,
+            name = entry.name,
             ids = entry.ids.map { it.id },
             state = entry.state.name.lowercase(),
             verdict = verdictLabel(entry.impact),

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/dto/ReportEntryDataDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/reporting/dto/ReportEntryDataDto.kt
@@ -5,6 +5,7 @@ package dev.vulnlog.lib.parse.reporting.dto
 
 data class ReportEntryDataDto(
     val primaryId: String,
+    val name: String?,
     val ids: List<String>,
     val state: String,
     val verdict: String,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/V1Mapper.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/v1/V1Mapper.kt
@@ -217,6 +217,7 @@ object V1Mapper {
         if (id == null || verdict == null) return null
         return VulnerabilityEntry(
             id = id,
+            name = dto.name,
             aliases = aliases,
             description = dto.description,
             releases = vulnerabilityReleasesToDomain(dto.releases),

--- a/modules/lib/src/main/resources/report/vulnlog-report-simple.html
+++ b/modules/lib/src/main/resources/report/vulnlog-report-simple.html
@@ -289,6 +289,10 @@
             font-size: 0.875rem;
         }
 
+        .vuln-name {
+            font-weight: 600;
+        }
+
         .details-label {
             font-weight: 600;
             color: var(--vl-text-secondary);
@@ -849,6 +853,15 @@
             }
 
             td.appendChild(meta);
+
+            // Common name (only if present)
+            if (e.name) {
+                var name = document.createElement('div');
+                name.className = 'details-block vuln-name';
+                name.appendChild(labelSpan('Name'));
+                name.appendChild(document.createTextNode(e.name));
+                td.appendChild(name);
+            }
 
             // Description (only if present)
             if (e.shortDescription) {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
@@ -46,6 +46,7 @@ private fun vulnlogFile(
 
 private fun vulnerability(
     id: VulnId = cve1,
+    name: String? = null,
     aliases: List<VulnId> = emptyList(),
     releases: List<Release> = listOf(releaseV1),
     analysis: String? = "not affected",
@@ -54,6 +55,7 @@ private fun vulnerability(
     description: String? = null,
 ) = VulnerabilityEntry(
     id = id,
+    name = name,
     aliases = aliases,
     releases = releases,
     packages = listOf(Purl.Maven("pkg:maven/com.example/lib@1.0")),
@@ -66,6 +68,7 @@ private fun vulnerability(
 
 private fun reportingEntry(
     primaryId: VulnId = cve1,
+    name: String? = null,
     state: WorkState = WorkState.OPEN,
     ids: Set<VulnId> = setOf(primaryId),
     impact: Impact = Impact.NotAffected("vulnerable code not in execute path"),
@@ -75,6 +78,7 @@ private fun reportingEntry(
     shortDescription: String? = null,
 ) = ReportingEntry(
     primaryId = primaryId,
+    name = name,
     state = state,
     ids = ids,
     shortDescription = shortDescription,
@@ -98,6 +102,14 @@ class ReportingTest :
                 val entry = result.first()
                 entry.primaryId shouldBe cve1
                 entry.ids shouldBe setOf(ghsa1)
+            }
+
+            test("maps common name") {
+                val file = vulnlogFile(vulnerabilities = listOf(vulnerability(name = "Log4Shell")))
+
+                val result = collectReportingEntries(file)
+
+                result.first().name shouldBe "Log4Shell"
             }
 
             test("maps fixedIn as set from resolution") {
@@ -323,6 +335,16 @@ class ReportingTest :
 
                 result shouldHaveSize 1
                 result.first().shortDescription shouldBe "RCE in lib"
+            }
+
+            test("picks first non-null common name") {
+                val entry1 = reportingEntry(name = null)
+                val entry2 = reportingEntry(name = "Log4Shell")
+
+                val result = mergeReportingEntries(listOf(entry1, entry2))
+
+                result shouldHaveSize 1
+                result.first().name shouldBe "Log4Shell"
             }
 
             test("keeps entries separate when verdict differs") {

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/v1/V1MapperTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/v1/V1MapperTest.kt
@@ -224,6 +224,28 @@ class V1MapperTest :
             }
         }
 
+        context("toDomain — vulnerability mapping") {
+            test("common name is mapped from dto") {
+                val dto =
+                    minimalDto(
+                        vulnerabilities =
+                            listOf(
+                                VulnerabilityEntryDto(
+                                    id = "CVE-2021-44228",
+                                    name = "Log4Shell",
+                                    releases = emptyList(),
+                                    packages = emptyList(),
+                                    reports = emptyList(),
+                                ),
+                            ),
+                    )
+
+                toDomain(dto)
+                    .vulnerabilities[0]
+                    .name shouldBe "Log4Shell"
+            }
+        }
+
         context("toDomain — vulnerability verdict mapping") {
             test("null verdict maps to UnderInvestigation") {
                 val dto =

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportRendererTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/render/HtmlReportRendererTest.kt
@@ -25,6 +25,7 @@ private val emptyFilter = FilterDataDto(release = null, tags = emptyList(), repo
 
 private fun entry(
     primaryId: VulnId = VulnId.Cve("CVE-2026-1234"),
+    name: String? = null,
     ids: Set<VulnId> = setOf(primaryId),
     state: WorkState = WorkState.OPEN,
     impact: Impact = Impact.Affected(Severity.HIGH),
@@ -34,6 +35,7 @@ private fun entry(
     description: String? = "RCE in example-lib",
 ) = ReportingEntry(
     primaryId = primaryId,
+    name = name,
     state = state,
     ids = ids,
     shortDescription = description,
@@ -77,6 +79,12 @@ class HtmlReportRendererTest :
             html shouldContain "CVE-2026-1234"
             html shouldContain "affected"
             html shouldContain "high"
+        }
+
+        test("includes common name in serialized entry data") {
+            val html = render(listOf(entry(name = "Log4Shell")))
+
+            html shouldContain "Log4Shell"
         }
 
         test("placeholder is replaced") {

--- a/modules/lib/src/test/resources/report/golden-vulnlog-report-simple.html
+++ b/modules/lib/src/test/resources/report/golden-vulnlog-report-simple.html
@@ -289,6 +289,10 @@
             font-size: 0.875rem;
         }
 
+        .vuln-name {
+            font-weight: 600;
+        }
+
         .details-label {
             font-weight: 600;
             color: var(--vl-text-secondary);
@@ -549,7 +553,7 @@
 </footer>
 
 <script>
-    var VULNLOG_DATA = {"project":{"organization":"Acme Corp","name":"Acme Web App","author":"Security Team"},"generatedAt":"2026-05-02T10:30:00Z","vulnlogVersion":"1.2.3-test","inputs":["frontend.vl","backend.vl"],"filter":{"release":"1.1.0","tags":["production"],"reporter":"trivy"},"entries":[{"primaryId":"CVE-2026-1111","ids":["CVE-2026-1111","GHSA-aaaa-bbbb-cccc"],"state":"open","verdict":"affected","severity":"critical","verdictDetail":null,"shortDescription":"Critical RCE in example-lib","analysis":"Confirmed exploitable on the public ingress path; patch in progress.","releases":["1.0.0","1.1.0"],"fixedIn":["1.2.0"]},{"primaryId":"CVE-2026-2222","ids":["CVE-2026-2222"],"state":"open","verdict":"not affected","severity":null,"verdictDetail":"vulnerable code not in execute path","shortDescription":null,"analysis":null,"releases":["1.1.0"],"fixedIn":[]},{"primaryId":"CVE-2026-3333","ids":["CVE-2026-3333"],"state":"resolved","verdict":"affected","severity":"medium","verdictDetail":null,"shortDescription":"DoS via large payload","analysis":"Mitigated by request size limits at the edge.","releases":["1.0.0"],"fixedIn":["1.0.1"]}]};
+    var VULNLOG_DATA = {"project":{"organization":"Acme Corp","name":"Acme Web App","author":"Security Team"},"generatedAt":"2026-05-02T10:30:00Z","vulnlogVersion":"1.2.3-test","inputs":["frontend.vl","backend.vl"],"filter":{"release":"1.1.0","tags":["production"],"reporter":"trivy"},"entries":[{"primaryId":"CVE-2026-1111","name":null,"ids":["CVE-2026-1111","GHSA-aaaa-bbbb-cccc"],"state":"open","verdict":"affected","severity":"critical","verdictDetail":null,"shortDescription":"Critical RCE in example-lib","analysis":"Confirmed exploitable on the public ingress path; patch in progress.","releases":["1.0.0","1.1.0"],"fixedIn":["1.2.0"]},{"primaryId":"CVE-2026-2222","name":null,"ids":["CVE-2026-2222"],"state":"open","verdict":"not affected","severity":null,"verdictDetail":"vulnerable code not in execute path","shortDescription":null,"analysis":null,"releases":["1.1.0"],"fixedIn":[]},{"primaryId":"CVE-2026-3333","name":null,"ids":["CVE-2026-3333"],"state":"resolved","verdict":"affected","severity":"medium","verdictDetail":null,"shortDescription":"DoS via large payload","analysis":"Mitigated by request size limits at the edge.","releases":["1.0.0"],"fixedIn":["1.0.1"]}]};
     (function () {
         var COLUMN_META = {
             ids: {label: 'IDs', width: '16%', tooltip: 'Vulnerability identifiers (CVE, GHSA, SNYK)'},
@@ -849,6 +853,15 @@
             }
 
             td.appendChild(meta);
+
+            // Common name (only if present)
+            if (e.name) {
+                var name = document.createElement('div');
+                name.className = 'details-block vuln-name';
+                name.appendChild(labelSpan('Name'));
+                name.appendChild(document.createTextNode(e.name));
+                td.appendChild(name);
+            }
 
             // Description (only if present)
             if (e.shortDescription) {


### PR DESCRIPTION
Fixes #192.

This keeps the vulnerability `name` when mapping v1 files into the domain model, carries it through report data, and shows it in the HTML report when present.

I added focused coverage for the mapper, report collection/merge, and rendered report data. Local Gradle tests could not run on this machine because Java is not installed.