### PR TITLE
fix: Normalize vulnerability IDs when parsing

### DIFF
--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Vulnerability.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Vulnerability.kt
@@ -17,10 +17,10 @@ import dev.vulnlog.lib.model.VulnId
  */
 fun parseVulnId(id: String): VulnId =
     when {
-        id.startsWith("CVE-", ignoreCase = true) -> VulnId.Cve(id)
-        id.startsWith("GHSA-", ignoreCase = true) -> VulnId.Ghsa(id)
-        id.startsWith("RUSTSEC-", ignoreCase = true) -> VulnId.RustSec(id)
-        id.startsWith("SNYK-", ignoreCase = true) -> VulnId.Snyk(id)
+        id.startsWith("CVE-", ignoreCase = true) -> VulnId.Cve(id.uppercase())
+        id.startsWith("GHSA-", ignoreCase = true) -> VulnId.Ghsa(id.uppercase())
+        id.startsWith("RUSTSEC-", ignoreCase = true) -> VulnId.RustSec(id.uppercase())
+        id.startsWith("SNYK-", ignoreCase = true) -> VulnId.Snyk(id.uppercase())
         else -> throw IllegalArgumentException("Unsupported vulnerability ID: $id")
     }
 

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/AddTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/AddTest.kt
@@ -419,6 +419,33 @@ class AddTest :
                 outcome.newContent shouldContain "Existing comment."
             }
 
+            test("updates an existing entry when the supplied id differs only by case") {
+                val content =
+                    yamlWithEntries(
+                        """
+                        |  - id: "CVE-2026-1234"
+                        |    releases:
+                        |      - "1.0.0"
+                        |    packages: []
+                        |    reports: []
+                        """.trimMargin(),
+                    )
+
+                val outcome =
+                    addVulnerabilityToFile(
+                        parsed(content),
+                        DEFAULT_OPTIONS.copy(
+                            vulnId = parseVulnId("cve-2026-1234"),
+                            description = "Updated description.",
+                        ),
+                    )
+
+                outcome.updated shouldBe true
+                outcome.vulnId shouldBe VulnId.Cve("CVE-2026-1234")
+                outcome.newContent shouldContain "description: Updated description."
+                outcome.newContent.split("id: CVE-2026-1234").size - 1 shouldBe 1
+            }
+
             test("update with no --release keeps existing releases (no fallback to latest)") {
                 val existing =
                     VulnerabilityEntry(

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/VulnerabilityTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/VulnerabilityTest.kt
@@ -28,17 +28,19 @@ class VulnerabilityTest :
             test("parses CVE id case-insensitively") {
                 val result = parseVulnId("cve-2021-44228")
                 result.shouldBeInstanceOf<VulnId.Cve>()
+                result.id shouldBe "CVE-2021-44228"
             }
 
             test("parses GHSA id") {
                 val result = parseVulnId("GHSA-jfh8-c2jp-hdp7")
                 result.shouldBeInstanceOf<VulnId.Ghsa>()
-                result.id shouldBe "GHSA-jfh8-c2jp-hdp7"
+                result.id shouldBe "GHSA-JFH8-C2JP-HDP7"
             }
 
             test("parses GHSA id case-insensitively") {
                 val result = parseVulnId("ghsa-jfh8-c2jp-hdp7")
                 result.shouldBeInstanceOf<VulnId.Ghsa>()
+                result.id shouldBe "GHSA-JFH8-C2JP-HDP7"
             }
 
             test("parses RUSTSEC id") {
@@ -50,6 +52,7 @@ class VulnerabilityTest :
             test("parses RUSTSEC id case-insensitively") {
                 val result = parseVulnId("rustsec-2021-0001")
                 result.shouldBeInstanceOf<VulnId.RustSec>()
+                result.id shouldBe "RUSTSEC-2021-0001"
             }
 
             test("parses SNYK id") {
@@ -61,6 +64,7 @@ class VulnerabilityTest :
             test("parses SNYK id case-insensitively") {
                 val result = parseVulnId("snyk-java-foo-123")
                 result.shouldBeInstanceOf<VulnId.Snyk>()
+                result.id shouldBe "SNYK-JAVA-FOO-123"
             }
 
             test("throws on unsupported format") {


### PR DESCRIPTION
Fixes #193.

This canonicalizes vulnerability IDs as they are parsed, so inputs like `cve-...` and `CVE-...` compare as the same ID through add/copy/validation paths.

I added coverage for lower-case parsing and for updating an existing entry when the supplied ID only differs by case. Local Gradle tests could not run on this machine because Java is not installed.