### PR TITLE
feat: Add options to log verbose and debug output in CLI and Gradle plugin

### DIFF
--- a/devdoc/Logging.md
+++ b/devdoc/Logging.md
@@ -1,0 +1,80 @@
+# Logging
+
+How Vulnlog communicates on the terminal, and how to decide whether a new message belongs in the code and at what level.
+The CLI flags are `-v`, `-vv` and `-q`. The Gradle plugin emits the same events through the Gradle logger (`--info`
+shows verbose, `--debug` shows debug).
+
+## Channels
+
+- stdout carries command output only (YAML, HTML, suppression content). Redirections like
+  `vulnlog suppress -o - > .trivyignore.yaml` must stay safe at any verbosity.
+- Everything else is secondary: status lines print to stdout but are suppressible with `-q`. warnings, errors and
+  diagnostics go to stderr.
+- There is no log file. Users capture diagnostics by redirecting stderr.
+
+## Levels
+
+| Level   | Shown                  | Audience   | Purpose                                                                             |
+|---------|------------------------|------------|-------------------------------------------------------------------------------------|
+| status  | default, off with `-q` | user       | One line per completed user-visible action.                                         |
+| warning | always                 | user       | Surprising but non-fatal.                                                           |
+| error   | always                 | user       | The operation failed; one actionable line.                                          |
+| verbose | `-v`                   | user       | What the tool did with the user's data.                                             |
+| debug   | `-vv`                  | maintainer | Internal decisions for bug hunting; also enables stack traces on unexpected errors. |
+
+## Should this log at all, and at what level?
+
+The first match wins.
+
+1. Can the user infer it from the command output or an existing message? Do not log.
+2. Did the command create or change something the user asked for? Status.
+3. Is something surprising but not fatal (data loss on rewrite, deprecated usage)? Warning.
+4. Did a step fail? Error, once, with the reason and the file or id involved.
+5. Does it explain what happened to the user's data: a file parsed, a filter resolved, a file written, an entry skipped
+   and why? Verbose.
+6. Does it only help a maintainer diagnose: per-entry decisions, intermediate counts, why the code chose a branch?
+   Debug.
+7. Otherwise do not log. The goal is to not overload the verbosity features with unrelevant information.
+
+Two hard rules:
+
+- Every skip or drop decision and every file write must be observable at `-v`.
+- Never log whole file contents.
+
+## Typical messages
+
+Verbose answers "why is X (not) in the output?":
+
+```
+verbose: parsed vulnlog.yaml: schema version 1, releases: 2, tags: 1, vulnerabilities: 4
+verbose: release filter expanded to releases: 1.2.0, 1.2.1
+verbose: validated vulnlog.yaml: 2 warning(s)
+verbose: skipped CVE-2026-1234 for .snyk: the snyk format requires SNYK ids
+verbose: wrote .trivyignore.yaml: trivy format, 3 entries
+```
+
+Debug answers "what exactly did the code decide?":
+
+```
+debug: included CVE-2026-1234 for reporter trivy (expires 2026-09-01)
+debug: collected 12 report entries, merged to 9
+debug: [non-canonical-array-style] vulnerabilities[0].releases: Line 12: canonical style for this list is a flow array, e.g. key: [value].
+```
+
+## Architecture
+
+- `core` never logs. It returns data that carries the facts worth reporting, for example `SuppressionExclusion` or
+  `SuppressionCollectionResult`.
+- Shared `render*` functions in `modules/lib` turn that data into the exact message text, so the CLI and the Gradle
+  plugin cannot drift apart.
+- Shells emit through `DiagnosticSink` (`modules/lib/.../shell/Diagnostics.kt`). The CLI sink filters by `Verbosity` and
+  prefixes `verbose:`/`debug:` on stderr; the Gradle sink forwards to `logger.info`/`logger.debug`.
+- If producing a debug message costs real work, guard the call site: `verbosity.enables(DiagnosticLevel.DEBUG)` in the
+  CLI, `logger.isDebugEnabled` in Gradle.
+
+## Message style
+
+- Diagnostics: lowercase, verb-first, past tense (`parsed x`, `wrote y`, `skipped z: reason`), one line per event, no
+  trailing period, ASCII only.
+- Include the identifier the user would grep for: file name, vulnerability id, reporter.
+- Status lines keep the existing human style (`Formatted: ...`, `Validation OK`).

--- a/docs/modules/ROOT/pages/cli-fmt.adoc
+++ b/docs/modules/ROOT/pages/cli-fmt.adoc
@@ -16,6 +16,7 @@ vulnlog fmt <file...> [--check]
 
 | `--check`
 | Do not write changes. Exit non-zero, list the files that are not already formatted, and explain which canonical-style rules each file violates.
+With `-q` the listing is suppressed and only the exit code reports the result.
 
 | `-`
 | Read from STDIN and write the formatted document to STDOUT.

--- a/docs/modules/ROOT/pages/cli-overview.adoc
+++ b/docs/modules/ROOT/pages/cli-overview.adoc
@@ -22,7 +22,26 @@ No automatic file detection.
 
 | `--help`
 | Print help.
+
+| `-v, --verbose`
+| Print diagnostic lines prefixed `verbose:` on stderr.
+
+| `-vv`
+| Additionally print `debug:` lines and full stack traces on unexpected errors.
+
+| `-q, --quiet`
+| Suppress status lines. Errors and warnings always print. Cannot be combined with `-v`.
 |===
+
+== Diagnostics
+
+By default a command prints one status line per action, plus errors and warnings.
+`-v` adds diagnostic detail about what the tool did: one line per parsed input file, a validation summary per file, the releases and tags a filter expanded to, every written output file, and every entry excluded from an output with the reason.
+`-vv` adds debug detail aimed at bug reports: every entry included in a suppression file, the findings that caused a file to be reformatted, report entry counts before and after merging, and the full stack trace when an unexpected error occurs; without it, such errors show a single `error:` line.
+
+Diagnostics always go to stderr.
+Stdout carries only command output, so redirections like `vulnlog suppress --reporter trivy -o - > .trivyignore.yaml` are safe at any verbosity.
+There is no log file; to capture diagnostics, redirect stderr.
 
 == Filtering Flags
 

--- a/docs/modules/ROOT/pages/cli-suppress.adoc
+++ b/docs/modules/ROOT/pages/cli-suppress.adoc
@@ -93,6 +93,17 @@ NOTE: `-o` (including `-o -` for stdout) requires a single reporter.
 Set `--reporter` to pick one, or use an input that only applies to one reporter.
 To write all applicable suppression files in one go, use `--output-dir <dir>` instead.
 
+== Seeing what was skipped
+
+Not every entry ends up in a suppression file: a format only accepts matching identifier types (a CVE id cannot go into a `.snyk` file), resolved vulnerabilities are not suppressed, and expired suppressions are dropped.
+Run with `-v` to see each skipped entry and the reason:
+
+[source]
+----
+vulnlog -v suppress full-example.vl.yaml
+verbose: skipped CVE-2026-1234 for .snyk: the snyk format requires SNYK ids
+----
+
 == Output Examples
 
 .Generated Snyk suppression file

--- a/docs/modules/ROOT/pages/gradle-plugin.adoc
+++ b/docs/modules/ROOT/pages/gradle-plugin.adoc
@@ -33,6 +33,11 @@ vulnlog {
 | File collection of Vulnlog YAML files to operate on. Used by all tasks except `vulnlogInit`.
 |===
 
+== Diagnostics
+
+The tasks emit the same diagnostics as the CLI's `-v` and `-vv` flags through the Gradle logger.
+Run with `gradle --info` to see parsed inputs, validation summaries, filter resolution, written outputs, and skipped suppression entries; `gradle --debug` adds debug detail such as included suppression entries and report entry counts.
+
 == Tasks
 
 All tasks are registered in the `vulnlog` task group.

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/AddCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/AddCommand.kt
@@ -182,7 +182,8 @@ class AddCommand : CliktCommand(name = "add") {
                 echo(formatCommentsDroppedWarning(destination.path.toString()), err = true)
             }
             destination.path.writeText(outcome.newContent)
-            echo(formatAddOutcomeMessage(destination.path, outcome))
+            diagnosticSink().verbose("wrote ${destination.path}")
+            echoStatus(formatAddOutcomeMessage(destination.path, outcome))
         }
     }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliDiagnostics.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliDiagnostics.kt
@@ -1,0 +1,30 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import dev.vulnlog.lib.shell.DiagnosticSink
+import dev.vulnlog.lib.shell.renderDiagnostic
+
+class CliDiagnostics(
+    val verbosity: Verbosity,
+    private val echoErr: (String) -> Unit,
+) {
+    val sink: DiagnosticSink =
+        DiagnosticSink { event ->
+            if (verbosity.enables(event.level)) echoErr(renderDiagnostic(event))
+        }
+}
+
+fun CliktCommand.diagnostics(): CliDiagnostics =
+    currentContext.findObject<CliDiagnostics>() ?: CliDiagnostics(Verbosity()) { echo(it, err = true) }
+
+fun CliktCommand.diagnosticSink(): DiagnosticSink = diagnostics().sink
+
+fun CliktCommand.echoStatus(
+    message: String,
+    err: Boolean = false,
+) {
+    if (diagnostics().verbosity.statusEnabled) echo(message, err = err)
+}

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CliWrapper.kt
@@ -20,8 +20,11 @@ import dev.vulnlog.lib.shell.FileInputOption
 import dev.vulnlog.lib.shell.FileOutputOption
 import dev.vulnlog.lib.shell.FilterValidationException
 import dev.vulnlog.lib.shell.parseInputs
+import dev.vulnlog.lib.shell.renderFilterResolution
 import dev.vulnlog.lib.shell.renderParseFailures
+import dev.vulnlog.lib.shell.renderParsedInputs
 import dev.vulnlog.lib.shell.renderValidationFindings
+import dev.vulnlog.lib.shell.renderValidationSummary
 import dev.vulnlog.lib.shell.resolveReleaseFilter
 import dev.vulnlog.lib.shell.resolveTagsFilter
 import dev.vulnlog.lib.shell.validateFiles
@@ -52,6 +55,7 @@ fun CliktCommand.parseInputOrFail(inputs: List<FileInputOption>): Map<FileInputO
         echoHelpHint()
         throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)
     }
+    renderParsedInputs(parseResults.success).forEach { diagnosticSink().verbose(it) }
     return parseResults.success
 }
 
@@ -60,6 +64,7 @@ fun CliktCommand.validateParsedInputOrFailWithFailureOutput(
     renderedSeverities: Set<Severity> = setOf(Severity.ERROR),
 ): ValidationResults {
     val validationFindings = validateFiles(fileToResult)
+    renderValidationSummary(validationFindings).forEach { diagnosticSink().verbose(it) }
     val rendered = renderValidationFindings(validationFindings, renderedSeverities)
     if (rendered.isNotBlank()) {
         echo(rendered, err = true)
@@ -71,7 +76,7 @@ fun CliktCommand.validateParsedInputOrFailWithFailureOutput(
     return validationFindings
 }
 
-fun CliktCommand.printOutputSeparator() = echo("", err = true)
+fun CliktCommand.printOutputSeparator() = echoStatus("", err = true)
 
 fun OptionCallTransformContext.toOutputFileOption(output: String): FileOutputOption =
     if (output == "-") {
@@ -121,7 +126,9 @@ fun CliktCommand.resolveFilter(
     try {
         val releases = resolveReleaseFilter(filterOptions.releaseOption, vulnlogFile)
         val tags = resolveTagsFilter(filterOptions.tagsOptions, vulnlogFile)
-        VulnlogFilter(releases, tags, filterOptions.reporter)
+        val filter = VulnlogFilter(releases, tags, filterOptions.reporter)
+        renderFilterResolution(filter).forEach { diagnosticSink().verbose(it) }
+        filter
     } catch (e: FilterValidationException) {
         echo(e.message, err = true)
         echo(e.detail, err = true)

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/CopyCommand.kt
@@ -77,7 +77,8 @@ class CopyCommand : CliktCommand(name = "copy") {
                 echo(formatCommentsDroppedWarning(destination.path.toString()), err = true)
             }
             destination.path.writeText(outcome.newContent.content)
-            echo(formatCopiedMessage(destination.path, outcome.copied))
+            diagnosticSink().verbose("wrote ${destination.path}")
+            echoStatus(formatCopiedMessage(destination.path, outcome.copied))
         }
     }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/FmtCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/FmtCommand.kt
@@ -19,7 +19,10 @@ import dev.vulnlog.lib.core.formatYamlOutcome
 import dev.vulnlog.lib.core.renderFormatFinding
 import dev.vulnlog.lib.parse.createYamlMapper
 import dev.vulnlog.lib.parse.hasYamlComments
+import dev.vulnlog.lib.result.ParseResult
+import dev.vulnlog.lib.shell.DiagnosticLevel
 import dev.vulnlog.lib.shell.FileInputOption
+import tools.jackson.databind.ObjectMapper
 import kotlin.io.path.writeText
 
 class FmtCommand : CliktCommand(name = "fmt") {
@@ -62,33 +65,30 @@ class FmtCommand : CliktCommand(name = "fmt") {
                         is FormatOutcome.Unchanged -> if (!isCheck) echo(raw.content, trailingNewline = false)
                         is FormatOutcome.Reformatted ->
                             if (isCheck) {
-                                echo("Can be reformatted: <stdin>", err = true)
-                                checkFormat(parsedInput, mapper).forEach { finding ->
-                                    echo("  ${renderFormatFinding(finding)}", err = true)
-                                }
+                                echoCheckFindings("<stdin>", parsedInput, mapper)
                             } else {
                                 if (hasYamlComments(parsedInput.rootNode)) {
                                     echo(formatCommentsDroppedWarning("<stdin>"), err = true)
                                 }
+                                debugFormatFindings(parsedInput, mapper)
                                 echo(outcome.formatted.content, trailingNewline = false)
                             }
                     }
 
                 is FileInputOption.File ->
                     when (outcome) {
-                        is FormatOutcome.Unchanged -> echo("Already formatted: ${input.path}")
+                        is FormatOutcome.Unchanged -> echoStatus("Already formatted: ${input.path}")
                         is FormatOutcome.Reformatted ->
                             if (isCheck) {
-                                echo("Can be reformatted: ${input.path}")
-                                checkFormat(parsedInput, mapper).forEach { finding ->
-                                    echo("  ${renderFormatFinding(finding)}")
-                                }
+                                echoCheckFindings(input.path.toString(), parsedInput, mapper)
                             } else {
                                 if (hasYamlComments(parsedInput.rootNode)) {
                                     echo(formatCommentsDroppedWarning(input.path.toString()), err = true)
                                 }
+                                debugFormatFindings(parsedInput, mapper)
                                 input.path.writeText(outcome.formatted.content)
-                                echo("Formatted: ${input.path}")
+                                diagnosticSink().verbose("wrote ${input.path}")
+                                echoStatus("Formatted: ${input.path}")
                             }
                     }
             }
@@ -96,6 +96,27 @@ class FmtCommand : CliktCommand(name = "fmt") {
 
         if (isCheck && anyUnformatted) {
             throw ProgramResult(ExitCode.FORMAT_ERROR.ordinal)
+        }
+    }
+
+    private fun echoCheckFindings(
+        source: String,
+        parsedInput: ParseResult.Ok,
+        mapper: ObjectMapper,
+    ) {
+        echoStatus("Can be reformatted: $source")
+        checkFormat(parsedInput, mapper).forEach { finding ->
+            echoStatus("  ${renderFormatFinding(finding)}")
+        }
+    }
+
+    private fun debugFormatFindings(
+        parsedInput: ParseResult.Ok,
+        mapper: ObjectMapper,
+    ) {
+        if (!diagnostics().verbosity.enables(DiagnosticLevel.DEBUG)) return
+        checkFormat(parsedInput, mapper).forEach { finding ->
+            diagnosticSink().debug(renderFormatFinding(finding))
         }
     }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/InitCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/InitCommand.kt
@@ -45,13 +45,15 @@ class InitCommand : CliktCommand(name = "init") {
         val content = YamlWriter.write(vulnlogFile, mapper)
 
         when (val target = output) {
-            is FileOutputOption.File ->
+            is FileOutputOption.File -> {
                 writeInit(
-                    { echo(it) },
+                    { echoStatus(it) },
                     { echo(it, err = true) },
                     target,
                     content,
                 )
+                diagnosticSink().verbose("wrote ${target.path}")
+            }
 
             is FileOutputOption.Stdout -> echo(content)
         }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
@@ -4,13 +4,24 @@
 package dev.vulnlog.cli.shell
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.obj
+import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.counted
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
 import dev.vulnlog.cli.BuildInfo
+import kotlin.system.exitProcess
 
-fun main(args: Array<String>) =
+fun main(args: Array<String>) {
+    exitProcess(runVulnlog(vulnlogCommand(), args.asList()))
+}
+
+fun vulnlogCommand(): VulnlogCli =
     VulnlogCli()
         .subcommands(InitCommand())
         .subcommands(ValidateCommand())
@@ -18,15 +29,66 @@ fun main(args: Array<String>) =
         .subcommands(SuppressCommand())
         .subcommands(ReportCommand())
         .subcommands(ModifyCommand())
-        .main(args)
+
+internal fun runVulnlog(
+    cli: VulnlogCli,
+    args: List<String>,
+    printError: (String) -> Unit = { message -> cli.echoSafely(message) },
+): Int =
+    try {
+        cli.parse(args)
+        ExitCode.SUCCESS.ordinal
+    } catch (e: CliktError) {
+        cli.echoFormattedHelp(e)
+        e.statusCode
+    } catch (e: Exception) {
+        renderUnexpectedError(e, cli.verbosity.stackTraces).forEach(printError)
+        ExitCode.GENERAL_ERROR.ordinal
+    }
+
+internal fun renderUnexpectedError(
+    e: Throwable,
+    stackTrace: Boolean,
+): List<String> =
+    listOfNotNull(
+        "error: ${e.message ?: e::class.simpleName}",
+        e.stackTraceToString().takeIf { stackTrace },
+    )
+
+private fun VulnlogCli.echoSafely(message: String) =
+    try {
+        echo(message, err = true)
+    } catch (_: IllegalStateException) {
+        System.err.println(message)
+    }
 
 class VulnlogCli : CliktCommand(name = "vulnlog") {
     init {
         versionOption(BuildInfo.VERSION)
     }
 
+    private val verbose: Int by option(
+        "-v",
+        "--verbose",
+        help = "Print verbose diagnostics on stderr. Repeat (-vv) for more verbose output.",
+    ).counted(limit = 2)
+
+    private val quiet: Boolean by option(
+        "-q",
+        "--quiet",
+        help = "Suppress status lines. Errors and warnings still print.",
+    ).flag()
+
+    var verbosity: Verbosity = Verbosity()
+
     override fun helpEpilog(context: Context): String =
         "Questions or feedback? Join the discussion at https://github.com/vulnlog/vulnlog/discussions"
 
-    override fun run() = Unit
+    override fun run() {
+        if (quiet && verbose > 0) {
+            throw UsageError("Option --quiet cannot be combined with --verbose.")
+        }
+        verbosity = Verbosity(level = verbose, quiet = quiet)
+        currentContext.obj = CliDiagnostics(verbosity) { message -> echo(message, err = true) }
+    }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ReportCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ReportCommand.kt
@@ -19,6 +19,7 @@ import dev.vulnlog.cli.BuildInfo
 import dev.vulnlog.lib.core.canonical
 import dev.vulnlog.lib.core.collectReportingEntries
 import dev.vulnlog.lib.core.mergeReportingEntries
+import dev.vulnlog.lib.core.renderReportingCounts
 import dev.vulnlog.lib.core.validateSharedProject
 import dev.vulnlog.lib.parse.reporting.HtmlReportMapper.toDto
 import dev.vulnlog.lib.parse.reporting.HtmlReportWriter.renderHtmlReport
@@ -65,6 +66,7 @@ class ReportCommand : CliktCommand(name = "report") {
         val allEntries =
             vulnlogFiles.flatMap { collectReportingEntries(it, filter) }
         val merged = mergeReportingEntries(allEntries)
+        diagnosticSink().debug(renderReportingCounts(allEntries.size, merged.size))
 
         val filterData =
             FilterDataDto(
@@ -86,13 +88,15 @@ class ReportCommand : CliktCommand(name = "report") {
         val content = renderHtmlReport(reportData)
 
         when (val target = output) {
-            is FileOutputOption.File ->
+            is FileOutputOption.File -> {
                 writeReport(
-                    { echo(it) },
+                    { echoStatus(it) },
                     { echo(it, err = true) },
                     target,
                     content,
                 )
+                diagnosticSink().verbose("wrote ${target.path}")
+            }
 
             is FileOutputOption.Stdout -> echo(content)
         }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/SuppressCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/SuppressCommand.kt
@@ -22,6 +22,10 @@ import dev.vulnlog.lib.core.SuppressionFilter
 import dev.vulnlog.lib.core.buildSuppressionOutputs
 import dev.vulnlog.lib.core.canonical
 import dev.vulnlog.lib.core.collectSuppressedVulnerabilities
+import dev.vulnlog.lib.core.renderSuppressionExclusion
+import dev.vulnlog.lib.core.renderSuppressionInclusions
+import dev.vulnlog.lib.core.renderSuppressionWritten
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
 import dev.vulnlog.lib.parse.suppression.SuppressionFile
 import dev.vulnlog.lib.parse.suppression.SuppressionWriter.writeSuppressionOutput
 import dev.vulnlog.lib.shell.DirectoryOutputOption
@@ -82,13 +86,17 @@ class SuppressCommand : CliktCommand(name = "suppress") {
                 .filter { filter.reporter == null || it == filter.reporter }
                 .toSet()
 
-        val suppressionVulns =
-            collectSuppressedVulnerabilities(vulnlogFile, SuppressionFilter(filter))
-        val outputSuppressions = buildSuppressionOutputs(targetReporters, suppressionVulns, format)
-        val contents: List<SuppressionFile> = outputSuppressions.map(::writeSuppressionOutput)
+        val collected = collectSuppressedVulnerabilities(vulnlogFile, SuppressionFilter(filter))
+        val suppressionResult = buildSuppressionOutputs(targetReporters, collected.included, format)
+        (collected.exclusions + suppressionResult.exclusions).forEach { exclusion ->
+            diagnosticSink().verbose(renderSuppressionExclusion(exclusion))
+        }
+        renderSuppressionInclusions(collected.included).forEach { diagnosticSink().debug(it) }
+        val contents: List<RenderedSuppression> =
+            suppressionResult.outputs.map { output -> RenderedSuppression(output, writeSuppressionOutput(output)) }
 
         if (contents.isEmpty()) {
-            echo("No suppression entries applicable; nothing written.", err = true)
+            echoStatus("No suppression entries applicable; nothing written.", err = true)
             return
         }
 
@@ -104,35 +112,45 @@ class SuppressCommand : CliktCommand(name = "suppress") {
         when (val resolved = destination) {
             is DirectoryOutputOption.Directory -> writeToDirectory(resolved, contents)
             is FileOutputOption.File -> writeSingleFileOutput(resolved, contents.first())
-            FileOutputOption.Stdout -> echo(contents.first().content)
+            FileOutputOption.Stdout -> {
+                echo(contents.first().file.content)
+                diagnosticSink().verbose(renderSuppressionWritten("<stdout>", contents.first().output))
+            }
         }
     }
 
     private fun writeToDirectory(
         destination: DirectoryOutputOption.Directory,
-        suppressionFiles: List<SuppressionFile>,
+        suppressions: List<RenderedSuppression>,
     ) {
-        suppressionFiles.forEach { suppressionFile ->
+        suppressions.forEach { (output, suppressionFile) ->
             val outputPath: Path = destination.path.resolve(suppressionFile.fileName)
             writeSuppressionFile(
-                { echo(it) },
+                { echoStatus(it) },
                 { echo(it, err = true) },
                 outputPath,
                 suppressionFile,
             )
+            diagnosticSink().verbose(renderSuppressionWritten(outputPath.toString(), output))
         }
     }
 
     private fun writeSingleFileOutput(
         destination: FileOutputOption.File,
-        suppressionFile: SuppressionFile,
+        suppression: RenderedSuppression,
     ) {
         val outputPath = destination.path
         writeSuppressionFile(
-            { echo(it) },
+            { echoStatus(it) },
             { echo(it, err = true) },
             outputPath,
-            suppressionFile,
+            suppression.file,
         )
+        diagnosticSink().verbose(renderSuppressionWritten(outputPath.toString(), suppression.output))
     }
 }
+
+private data class RenderedSuppression(
+    val output: SuppressionOutput,
+    val file: SuppressionFile,
+)

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ValidateCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/ValidateCommand.kt
@@ -37,6 +37,6 @@ class ValidateCommand : CliktCommand(name = "validate") {
         if (validationFindings.hasWarnings && strict) {
             throw ProgramResult(ExitCode.VALIDATION_ERROR.ordinal)
         }
-        echo("Validation OK")
+        echoStatus("Validation OK")
     }
 }

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Verbosity.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Verbosity.kt
@@ -1,0 +1,21 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import dev.vulnlog.lib.shell.DiagnosticLevel
+
+data class Verbosity(
+    val level: Int = 0,
+    val quiet: Boolean = false,
+) {
+    val stackTraces: Boolean get() = level >= 2
+
+    val statusEnabled: Boolean get() = !quiet
+
+    fun enables(diagnosticLevel: DiagnosticLevel): Boolean =
+        when (diagnosticLevel) {
+            DiagnosticLevel.VERBOSE -> level >= 1
+            DiagnosticLevel.DEBUG -> level >= 2
+        }
+}

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/FmtCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/FmtCommandTest.kt
@@ -201,6 +201,54 @@ class FmtCommandTest :
                     result.statusCode shouldBe 0
                 }
             }
+
+            test("lists STDIN findings on stdout like file findings") {
+                withStdin(UGLY_YAML) {
+                    val result = FmtCommand().test("--check -")
+
+                    result.statusCode shouldBe ExitCode.FORMAT_ERROR.ordinal
+                    result.stdout shouldContain "Can be reformatted: <stdin>"
+                }
+            }
+
+            test("-q suppresses the listing and keeps the exit code") {
+                withTempFile(prefix = "fmt", content = UGLY_YAML) { file ->
+                    val result = vulnlogCommand().test("-q fmt --check ${file.absolutePath}")
+
+                    result.statusCode shouldBe ExitCode.FORMAT_ERROR.ordinal
+                    result.stdout shouldNotContain "Can be reformatted"
+                }
+            }
+        }
+
+        context("diagnostics") {
+
+            test("-v reports the rewritten file on stderr") {
+                withTempFile(prefix = "fmt", content = UGLY_YAML) { file ->
+                    val result = vulnlogCommand().test("-v fmt ${file.absolutePath}")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldContain "verbose: wrote ${file.absolutePath}"
+                }
+            }
+
+            test("-vv explains why the file was rewritten") {
+                withTempFile(prefix = "fmt", content = UGLY_YAML) { file ->
+                    val result = vulnlogCommand().test("-vv fmt ${file.absolutePath}")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldContain "debug: [non-canonical-array-style]"
+                }
+            }
+
+            test("-v alone does not explain the rewrite") {
+                withTempFile(prefix = "fmt", content = UGLY_YAML) { file ->
+                    val result = vulnlogCommand().test("-v fmt ${file.absolutePath}")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldNotContain "non-canonical"
+                }
+            }
         }
 
         context("stdin/stdout") {

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/MainTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/MainTest.kt
@@ -1,0 +1,130 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+private class BoomCommand : CliktCommand(name = "boom") {
+    override fun run(): Unit = throw IllegalStateException("kaboom")
+}
+
+private class OkCommand : CliktCommand(name = "ok") {
+    override fun run() = Unit
+}
+
+private fun cliWith(command: CliktCommand): VulnlogCli = VulnlogCli().subcommands(command)
+
+private inline fun <R> withCapturedStderr(block: () -> R): Pair<R, String> {
+    val original = System.err
+    val buffer = ByteArrayOutputStream()
+    return try {
+        System.setErr(PrintStream(buffer))
+        block() to buffer.toString()
+    } finally {
+        System.setErr(original)
+    }
+}
+
+private inline fun <R> withCapturedStdout(block: () -> R): Pair<R, String> {
+    val original = System.out
+    val buffer = ByteArrayOutputStream()
+    return try {
+        System.setOut(PrintStream(buffer))
+        block() to buffer.toString()
+    } finally {
+        System.setOut(original)
+    }
+}
+
+class MainTest :
+    FunSpec({
+
+        context("renderUnexpectedError") {
+
+            test("renders a single error line by default") {
+                renderUnexpectedError(IllegalStateException("kaboom"), stackTrace = false) shouldBe
+                    listOf("error: kaboom")
+            }
+
+            test("falls back to the exception class name without a message") {
+                renderUnexpectedError(IllegalStateException(), stackTrace = false) shouldBe
+                    listOf("error: IllegalStateException")
+            }
+
+            test("appends the stack trace when requested") {
+                val lines = renderUnexpectedError(IllegalStateException("kaboom"), stackTrace = true)
+
+                lines shouldHaveSize 2
+                lines[0] shouldBe "error: kaboom"
+                lines[1] shouldContain "java.lang.IllegalStateException: kaboom"
+                lines[1] shouldContain "\tat "
+            }
+        }
+
+        context("runVulnlog") {
+
+            test("returns success for a completed command") {
+                runVulnlog(cliWith(OkCommand()), listOf("ok")) shouldBe ExitCode.SUCCESS.ordinal
+            }
+
+            test("reports an unexpected exception as a single error line") {
+                val lines = mutableListOf<String>()
+
+                val exit = runVulnlog(cliWith(BoomCommand()), listOf("boom"), lines::add)
+
+                exit shouldBe ExitCode.GENERAL_ERROR.ordinal
+                lines shouldBe listOf("error: kaboom")
+            }
+
+            test("-vv adds the stack trace") {
+                val lines = mutableListOf<String>()
+
+                val exit = runVulnlog(cliWith(BoomCommand()), listOf("-vv", "boom"), lines::add)
+
+                exit shouldBe ExitCode.GENERAL_ERROR.ordinal
+                lines shouldHaveSize 2
+                lines[0] shouldBe "error: kaboom"
+                lines[1] shouldContain "IllegalStateException"
+            }
+
+            test("prints to stderr by default") {
+                val (exit, stderr) =
+                    withCapturedStderr {
+                        runVulnlog(cliWith(BoomCommand()), listOf("boom"))
+                    }
+
+                exit shouldBe ExitCode.GENERAL_ERROR.ordinal
+                stderr shouldContain "error: kaboom"
+                stderr shouldNotContain "\tat "
+            }
+
+            test("unknown subcommands keep the usage error behavior") {
+                val (exit, stderr) =
+                    withCapturedStderr {
+                        runVulnlog(cliWith(OkCommand()), listOf("nope"))
+                    }
+
+                exit shouldBe ExitCode.GENERAL_ERROR.ordinal
+                stderr shouldContain "nope"
+            }
+
+            test("--help exits with success") {
+                val (exit, stdout) =
+                    withCapturedStdout {
+                        runVulnlog(cliWith(OkCommand()), listOf("--help"))
+                    }
+
+                exit shouldBe ExitCode.SUCCESS.ordinal
+                stdout shouldContain "Usage"
+            }
+        }
+    })

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/VulnlogCliTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/VulnlogCliTest.kt
@@ -1,0 +1,381 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.testing.test
+import dev.vulnlog.lib.shell.DiagnosticLevel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.paths.shouldExist
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+private class ProbeCommand : CliktCommand(name = "probe") {
+    var seen: Verbosity? = null
+
+    override fun run() {
+        seen = diagnostics().verbosity
+    }
+}
+
+class VulnlogCliTest :
+    FunSpec({
+
+        fun cliWithProbe(): Pair<VulnlogCli, ProbeCommand> {
+            val probe = ProbeCommand()
+            return VulnlogCli().subcommands(probe) to probe
+        }
+
+        context("verbosity flags") {
+
+            test("defaults to no diagnostics and status lines on") {
+                val (cli, probe) = cliWithProbe()
+
+                cli.test("probe").statusCode shouldBe 0
+
+                probe.seen shouldBe Verbosity(level = 0, quiet = false)
+            }
+
+            test("-v enables verbose") {
+                val (cli, probe) = cliWithProbe()
+
+                cli.test("-v probe").statusCode shouldBe 0
+
+                probe.seen shouldBe Verbosity(level = 1, quiet = false)
+            }
+
+            test("-vv enables debug") {
+                val (cli, probe) = cliWithProbe()
+
+                cli.test("-vv probe").statusCode shouldBe 0
+
+                probe.seen shouldBe Verbosity(level = 2, quiet = false)
+            }
+
+            test("--verbose is the long form of -v") {
+                val (cli, probe) = cliWithProbe()
+
+                cli.test("--verbose probe").statusCode shouldBe 0
+
+                probe.seen shouldBe Verbosity(level = 1, quiet = false)
+            }
+
+            test("-q sets quiet") {
+                val (cli, probe) = cliWithProbe()
+
+                cli.test("-q probe").statusCode shouldBe 0
+
+                probe.seen shouldBe Verbosity(level = 0, quiet = true)
+            }
+
+            test("-q with -v is a usage error") {
+                val (cli, _) = cliWithProbe()
+
+                val result = cli.test("-q -v probe")
+
+                result.statusCode shouldBe 1
+                result.stderr shouldContain "Option --quiet cannot be combined with --verbose."
+            }
+
+            test("-q with -vv is a usage error") {
+                val (cli, _) = cliWithProbe()
+
+                val result = cli.test("-q -vv probe")
+
+                result.statusCode shouldBe 1
+                result.stderr shouldContain "Option --quiet cannot be combined with --verbose."
+            }
+        }
+
+        context("Verbosity") {
+
+            test("level 0 enables nothing") {
+                Verbosity(level = 0).enables(DiagnosticLevel.VERBOSE).shouldBeFalse()
+                Verbosity(level = 0).enables(DiagnosticLevel.DEBUG).shouldBeFalse()
+            }
+
+            test("level 1 enables verbose only") {
+                Verbosity(level = 1).enables(DiagnosticLevel.VERBOSE).shouldBeTrue()
+                Verbosity(level = 1).enables(DiagnosticLevel.DEBUG).shouldBeFalse()
+            }
+
+            test("level 2 enables verbose and debug") {
+                Verbosity(level = 2).enables(DiagnosticLevel.VERBOSE).shouldBeTrue()
+                Verbosity(level = 2).enables(DiagnosticLevel.DEBUG).shouldBeTrue()
+            }
+
+            test("stack traces require level 2") {
+                Verbosity(level = 1).stackTraces.shouldBeFalse()
+                Verbosity(level = 2).stackTraces.shouldBeTrue()
+            }
+
+            test("quiet disables status lines") {
+                Verbosity(quiet = false).statusEnabled.shouldBeTrue()
+                Verbosity(quiet = true).statusEnabled.shouldBeFalse()
+            }
+        }
+
+        context("CliDiagnostics sink") {
+
+            test("level 0 emits nothing") {
+                val lines = mutableListOf<String>()
+
+                val diagnostics = CliDiagnostics(Verbosity(level = 0), lines::add)
+                diagnostics.sink.verbose("parsed")
+                diagnostics.sink.debug("timing")
+
+                lines shouldBe emptyList()
+            }
+
+            test("level 1 emits verbose only") {
+                val lines = mutableListOf<String>()
+
+                val diagnostics = CliDiagnostics(Verbosity(level = 1), lines::add)
+                diagnostics.sink.verbose("parsed")
+                diagnostics.sink.debug("timing")
+
+                lines shouldBe listOf("verbose: parsed")
+            }
+
+            test("level 2 emits verbose and debug") {
+                val lines = mutableListOf<String>()
+
+                val diagnostics = CliDiagnostics(Verbosity(level = 2), lines::add)
+                diagnostics.sink.verbose("parsed")
+                diagnostics.sink.debug("timing")
+
+                lines shouldBe listOf("verbose: parsed", "debug: timing")
+            }
+        }
+
+        test("subcommand without a parent context falls back to defaults") {
+            val probe = ProbeCommand()
+
+            probe.test("").statusCode shouldBe 0
+
+            probe.seen shouldBe Verbosity(level = 0, quiet = false)
+        }
+
+        context("quiet mode") {
+
+            test("validate stays silent on success") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    val result = vulnlogCommand().test("-q validate ${file.absolutePath}")
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldBe ""
+                    result.stderr shouldBe ""
+                }
+            }
+
+            test("validate without quiet prints the status line") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    val result = vulnlogCommand().test("validate ${file.absolutePath}")
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldContain "Validation OK"
+                }
+            }
+
+            test("suppress writes the file but no status line") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    withTempDir { dir ->
+                        val result =
+                            vulnlogCommand().test(
+                                "-q suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stdout shouldBe ""
+                        result.stderr shouldBe ""
+                        dir.resolve(".trivyignore.yaml").shouldExist()
+                    }
+                }
+            }
+
+            test("errors still print") {
+                withTempFile(content = INVALID_VULNLOG_YAML) { file ->
+                    val result = vulnlogCommand().test("-q validate ${file.absolutePath}")
+
+                    result.statusCode shouldBe ExitCode.VALIDATION_ERROR.ordinal
+                    result.stderr shouldContain file.name
+                }
+            }
+        }
+
+        context("verbose mode") {
+
+            test("suppress reports parsed inputs and written outputs on stderr") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    withTempDir { dir ->
+                        val result =
+                            vulnlogCommand().test(
+                                "-v suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain
+                            "verbose: parsed ${file.name}: schema version 1, releases: 1, tags: 0, vulnerabilities: 1"
+                        result.stderr shouldContain
+                            "verbose: wrote ${dir.resolve(".trivyignore.yaml")}: trivy format, 1 entry"
+                    }
+                }
+            }
+
+            test("without -v no verbose lines appear") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    withTempDir { dir ->
+                        val result =
+                            vulnlogCommand().test(
+                                "suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldNotContain "verbose:"
+                    }
+                }
+            }
+
+            test("report shows the filter expansion") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    withTempDir { dir ->
+                        val output = dir.resolve("report.html")
+                        val result =
+                            vulnlogCommand().test(
+                                "-v report ${file.absolutePath} --release 1.0.0 -o ${output.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain "verbose: release filter expanded to releases: 1.0.0"
+                        result.stderr shouldContain "verbose: wrote ${output.toAbsolutePath()}"
+                    }
+                }
+            }
+
+            test("suppress reports entries skipped for the output format") {
+                withTempFile(content = vulnlogYaml(reporter = "snyk")) { file ->
+                    withTempDir { dir ->
+                        val result =
+                            vulnlogCommand().test(
+                                "-v suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain
+                            "verbose: skipped CVE-2026-1234 for .snyk: the snyk format requires SNYK ids"
+                    }
+                }
+            }
+
+            test("skipped entries stay silent without -v") {
+                withTempFile(content = vulnlogYaml(reporter = "snyk")) { file ->
+                    withTempDir { dir ->
+                        val result =
+                            vulnlogCommand().test(
+                                "suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldNotContain "skipped"
+                    }
+                }
+            }
+
+            test("suppress reports expired suppressions") {
+                val expiredYaml =
+                    """
+                    ---
+                    schemaVersion: "1"
+
+                    project:
+                      organization: Acme Corp
+                      name: Acme Web App
+                      author: Acme Corp Security Team
+
+                    releases:
+                      - id: 1.0.0
+                        published_at: 2026-01-15
+
+                    vulnerabilities:
+
+                      - id: CVE-2026-1234
+                        releases: [ 1.0.0 ]
+                        description: Remote code execution in example-lib
+                        packages: [ "pkg:npm/example-lib@2.3.0" ]
+                        reports:
+                          - reporter: trivy
+                            suppress: { expires_at: 2026-02-01 }
+                        analysis: not reachable
+                        verdict: under_investigation
+                    """.trimIndent()
+                withTempFile(content = expiredYaml) { file ->
+                    withTempDir { dir ->
+                        val result =
+                            vulnlogCommand().test(
+                                "-v suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain
+                            "verbose: skipped CVE-2026-1234 for reporter trivy: suppression expired on 2026-02-01"
+                    }
+                }
+            }
+
+            test("validate shows a per-file validation summary") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    val result = vulnlogCommand().test("-v validate ${file.absolutePath}")
+
+                    result.statusCode shouldBe 0
+                    result.stderr shouldContain "verbose: validated ${file.name}: no findings"
+                }
+            }
+
+            test("verbosity never touches stdout") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    val plain = vulnlogCommand().test("suppress ${file.absolutePath} -o -")
+                    val verbose = vulnlogCommand().test("-vv suppress ${file.absolutePath} -o -")
+
+                    plain.statusCode shouldBe 0
+                    verbose.statusCode shouldBe 0
+                    verbose.stdout shouldBe plain.stdout
+                }
+            }
+        }
+
+        context("debug mode") {
+
+            test("suppress lists included entries only at -vv") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    withTempDir { dir ->
+                        val args = "suppress ${file.absolutePath} --output-dir ${dir.toAbsolutePath()}"
+                        val verbose = vulnlogCommand().test("-v $args")
+                        val debug = vulnlogCommand().test("-vv $args")
+
+                        verbose.stderr shouldNotContain "included CVE-2026-1234"
+                        debug.stderr shouldContain "debug: included CVE-2026-1234 for reporter trivy"
+                    }
+                }
+            }
+
+            test("report counts the collected and merged entries at -vv") {
+                withTempFile(content = vulnlogYaml()) { file ->
+                    withTempDir { dir ->
+                        val output = dir.resolve("report.html")
+                        val result =
+                            vulnlogCommand().test(
+                                "-vv report ${file.absolutePath} -o ${output.toAbsolutePath()}",
+                            )
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain "debug: collected 1 report entries, merged to 1"
+                    }
+                }
+            }
+        }
+    })

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogCopyTask.kt
@@ -3,6 +3,7 @@
 
 package dev.vulnlog.gradle
 
+import dev.vulnlog.gradle.internal.diagnosticSink
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
 import dev.vulnlog.lib.core.copyVulnerabilities
@@ -43,9 +44,10 @@ abstract class VulnlogCopyTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
+        val sink = diagnosticSink()
         val sourceInput = FileInputOption.File(sourceFile.get().asFile.toPath())
-        val parsedSource = parseInputOrFail(listOf(sourceInput))
-        validateParsedInputOrFailWithFailureOutput(parsedSource)
+        val parsedSource = parseInputOrFail(listOf(sourceInput), sink)
+        validateParsedInputOrFailWithFailureOutput(parsedSource, sink = sink)
         val sourceVulnlogFile = parsedSource.values.first().content
 
         val vulnIdSet = vulnIds.get().map { parseVulnId(it) }.toSet()
@@ -57,8 +59,8 @@ abstract class VulnlogCopyTask : DefaultTask() {
         val mapper = createYamlMapper()
         val destinations = destinationFiles.files.map { FileInputOption.File(it.toPath()) }
         for (destination in destinations) {
-            val parsedDestination = parseInputOrFail(listOf(destination))
-            validateParsedInputOrFailWithFailureOutput(parsedDestination)
+            val parsedDestination = parseInputOrFail(listOf(destination), sink)
+            validateParsedInputOrFailWithFailureOutput(parsedDestination, sink = sink)
             val destinationFile = parsedDestination.values.first()
 
             val outcome =
@@ -72,6 +74,7 @@ abstract class VulnlogCopyTask : DefaultTask() {
                 logger.warn(formatCommentsDroppedWarning(destination.path.toString()))
             }
             destination.path.writeText(outcome.newContent.content)
+            sink.verbose("wrote ${destination.path}")
             logger.lifecycle(formatCopiedMessage(destination.path, outcome.copied))
         }
     }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogFmtTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogFmtTask.kt
@@ -3,6 +3,7 @@
 
 package dev.vulnlog.gradle
 
+import dev.vulnlog.gradle.internal.diagnosticSink
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.lib.core.FormatOutcome
@@ -41,9 +42,10 @@ abstract class VulnlogFmtTask : DefaultTask() {
 
     @TaskAction
     fun format() {
+        val sink = diagnosticSink()
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
         requireNonEmptyVulnlogFiles(inputFiles)
-        val parsed = parseInputOrFail(inputFiles)
+        val parsed = parseInputOrFail(inputFiles, sink)
 
         val mapper = createYamlMapper()
         val checkOnly = check.getOrElse(false)
@@ -63,7 +65,13 @@ abstract class VulnlogFmtTask : DefaultTask() {
                         if (hasYamlComments(parsedInput.rootNode)) {
                             logger.warn(formatCommentsDroppedWarning(input.path.toString()))
                         }
+                        if (logger.isDebugEnabled) {
+                            checkFormat(parsedInput, mapper).forEach { finding ->
+                                sink.debug(renderFormatFinding(finding))
+                            }
+                        }
                         input.path.writeText(outcome.formatted.content)
+                        sink.verbose("wrote ${input.path}")
                         logger.lifecycle("Formatted: ${input.path}")
                     }
             }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogInitTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogInitTask.kt
@@ -3,6 +3,7 @@
 
 package dev.vulnlog.gradle
 
+import dev.vulnlog.gradle.internal.diagnosticSink
 import dev.vulnlog.lib.core.init
 import dev.vulnlog.lib.model.SchemaVersion
 import dev.vulnlog.lib.parse.YamlWriter
@@ -35,6 +36,7 @@ abstract class VulnlogInitTask : DefaultTask() {
         val content = YamlWriter.write(vulnlogFile, createYamlMapper())
         val file = outputFile.get().asFile
         file.writeText(content)
+        diagnosticSink().verbose("wrote ${file.path}")
         logger.lifecycle("Vulnlog file created at: ${file.absolutePath}")
     }
 }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogReportTask.kt
@@ -4,6 +4,7 @@
 package dev.vulnlog.gradle
 
 import dev.vulnlog.gradle.internal.buildFilterOrFail
+import dev.vulnlog.gradle.internal.diagnosticSink
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
@@ -11,6 +12,7 @@ import dev.vulnlog.lib.core.canonical
 import dev.vulnlog.lib.core.collectReportingEntries
 import dev.vulnlog.lib.core.mergeReportingEntries
 import dev.vulnlog.lib.core.parseReporter
+import dev.vulnlog.lib.core.renderReportingCounts
 import dev.vulnlog.lib.core.validateSharedProject
 import dev.vulnlog.lib.parse.reporting.HtmlReportMapper
 import dev.vulnlog.lib.parse.reporting.HtmlReportWriter
@@ -56,10 +58,11 @@ abstract class VulnlogReportTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
+        val sink = diagnosticSink()
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
         requireNonEmptyVulnlogFiles(inputFiles)
-        val parsedSuccessfully = parseInputOrFail(inputFiles)
-        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
+        val parsedSuccessfully = parseInputOrFail(inputFiles, sink)
+        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully, sink = sink)
 
         val vulnlogFiles = parsedSuccessfully.values.map(ParseResult.Ok::content)
 
@@ -67,10 +70,11 @@ abstract class VulnlogReportTask : DefaultTask() {
             validateSharedProject(vulnlogFiles)
                 ?: throw GradleException("All input files must share the same project metadata.")
 
-        val filter = buildFilterOrFail(vulnlogFiles.first(), reporter.orNull, release.orNull, tags.get())
+        val filter = buildFilterOrFail(vulnlogFiles.first(), reporter.orNull, release.orNull, tags.get(), sink)
 
         val allEntries = vulnlogFiles.flatMap { collectReportingEntries(it, filter) }
         val merged = mergeReportingEntries(allEntries)
+        sink.debug(renderReportingCounts(allEntries.size, merged.size))
 
         val filterData =
             FilterDataDto(
@@ -94,6 +98,7 @@ abstract class VulnlogReportTask : DefaultTask() {
         val out = outputFile.get().asFile
         out.parentFile?.mkdirs()
         out.writeText(reportContent)
+        sink.verbose("wrote ${out.path}")
         logger.lifecycle("Report written to: ${out.absolutePath}")
     }
 }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogSuppressTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogSuppressTask.kt
@@ -4,12 +4,16 @@
 package dev.vulnlog.gradle
 
 import dev.vulnlog.gradle.internal.buildFilterOrFail
+import dev.vulnlog.gradle.internal.diagnosticSink
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.requireSingleVulnlogFile
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
 import dev.vulnlog.lib.core.SuppressionFilter
 import dev.vulnlog.lib.core.buildSuppressionOutputs
 import dev.vulnlog.lib.core.collectSuppressedVulnerabilities
+import dev.vulnlog.lib.core.renderSuppressionExclusion
+import dev.vulnlog.lib.core.renderSuppressionInclusions
+import dev.vulnlog.lib.core.renderSuppressionWritten
 import dev.vulnlog.lib.parse.suppression.SuppressionWriter
 import dev.vulnlog.lib.shell.FileInputOption
 import dev.vulnlog.lib.shell.SuppressionFormatRequest
@@ -53,13 +57,14 @@ abstract class VulnlogSuppressTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
+        val sink = diagnosticSink()
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
         requireSingleVulnlogFile("vulnlogSuppress", inputFiles)
-        val parsedSuccessfully = parseInputOrFail(inputFiles)
-        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully)
+        val parsedSuccessfully = parseInputOrFail(inputFiles, sink)
+        validateParsedInputOrFailWithFailureOutput(parsedSuccessfully, sink = sink)
 
         val vulnlogFile = parsedSuccessfully.values.first().content
-        val filter = buildFilterOrFail(vulnlogFile, reporter.orNull, release.orNull, tags.get())
+        val filter = buildFilterOrFail(vulnlogFile, reporter.orNull, release.orNull, tags.get(), sink)
 
         val targetReporters =
             vulnlogFile.vulnerabilities
@@ -68,12 +73,17 @@ abstract class VulnlogSuppressTask : DefaultTask() {
                 .filter { filter.reporter == null || it == filter.reporter }
                 .toSet()
 
-        val suppressionVulns = collectSuppressedVulnerabilities(vulnlogFile, SuppressionFilter(filter))
+        val collected = collectSuppressedVulnerabilities(vulnlogFile, SuppressionFilter(filter))
         val suppressionFormatRequest: SuppressionFormatRequest =
             SuppressionFormatRequest.fromToken(
                 format.getOrElse("auto"),
             )
-        val outputs = buildSuppressionOutputs(targetReporters, suppressionVulns, suppressionFormatRequest)
+        val suppressionResult = buildSuppressionOutputs(targetReporters, collected.included, suppressionFormatRequest)
+        (collected.exclusions + suppressionResult.exclusions).forEach { exclusion ->
+            sink.verbose(renderSuppressionExclusion(exclusion))
+        }
+        renderSuppressionInclusions(collected.included).forEach(sink::debug)
+        val outputs = suppressionResult.outputs
 
         val dir = outputDir.get().asFile
         dir.mkdirs()
@@ -82,6 +92,7 @@ abstract class VulnlogSuppressTask : DefaultTask() {
             val outputPath = dir.resolve(suppressionFile.fileName)
             outputPath.writeText(suppressionFile.content)
             logger.lifecycle("Suppression file created at: ${outputPath.absolutePath}")
+            sink.verbose(renderSuppressionWritten(outputPath.path, suppressionOutput))
         }
     }
 }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogValidateTask.kt
@@ -3,6 +3,7 @@
 
 package dev.vulnlog.gradle
 
+import dev.vulnlog.gradle.internal.diagnosticSink
 import dev.vulnlog.gradle.internal.parseInputOrFail
 import dev.vulnlog.gradle.internal.requireNonEmptyVulnlogFiles
 import dev.vulnlog.gradle.internal.validateParsedInputOrFailWithFailureOutput
@@ -30,13 +31,15 @@ abstract class VulnlogValidateTask : DefaultTask() {
 
     @TaskAction
     fun validate() {
+        val sink = diagnosticSink()
         val inputFiles = files.files.map { FileInputOption.File(it.toPath()) }
         requireNonEmptyVulnlogFiles(inputFiles)
-        val parsedSuccessfully = parseInputOrFail(inputFiles)
+        val parsedSuccessfully = parseInputOrFail(inputFiles, sink)
         val validationFindings =
             validateParsedInputOrFailWithFailureOutput(
                 parsedSuccessfully,
                 renderedSeverities = Severity.entries.toSet(),
+                sink = sink,
             )
         if (validationFindings.hasWarnings && strict.get()) {
             throw GradleException("Vulnlog validation failed.")

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleDiagnostics.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleDiagnostics.kt
@@ -1,0 +1,20 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.gradle.internal
+
+import dev.vulnlog.lib.shell.DiagnosticLevel
+import dev.vulnlog.lib.shell.DiagnosticSink
+import org.gradle.api.DefaultTask
+
+/**
+ * Maps diagnostic events to the Gradle logger, so `gradle --info` and `--debug` show them without
+ * extra task properties. Gradle's own log levels replace the CLI's `verbose:`/`debug:` prefixes.
+ */
+fun DefaultTask.diagnosticSink(): DiagnosticSink =
+    DiagnosticSink { event ->
+        when (event.level) {
+            DiagnosticLevel.VERBOSE -> logger.info(event.message)
+            DiagnosticLevel.DEBUG -> logger.debug(event.message)
+        }
+    }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleWrapper.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/internal/GradleWrapper.kt
@@ -9,12 +9,16 @@ import dev.vulnlog.lib.result.ParseResult
 import dev.vulnlog.lib.result.ParseResults
 import dev.vulnlog.lib.result.Severity
 import dev.vulnlog.lib.result.ValidationResults
+import dev.vulnlog.lib.shell.DiagnosticSink
 import dev.vulnlog.lib.shell.FileInputOption
 import dev.vulnlog.lib.shell.FilterValidationException
 import dev.vulnlog.lib.shell.buildFilter
 import dev.vulnlog.lib.shell.parseInputs
+import dev.vulnlog.lib.shell.renderFilterResolution
 import dev.vulnlog.lib.shell.renderParseFailures
+import dev.vulnlog.lib.shell.renderParsedInputs
 import dev.vulnlog.lib.shell.renderValidationFindings
+import dev.vulnlog.lib.shell.renderValidationSummary
 import dev.vulnlog.lib.shell.validateFiles
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -36,7 +40,10 @@ fun requireSingleVulnlogFile(
     return inputFiles.single()
 }
 
-fun parseInputOrFail(inputFiles: List<FileInputOption.File>): Map<FileInputOption, ParseResult.Ok> {
+fun parseInputOrFail(
+    inputFiles: List<FileInputOption.File>,
+    sink: DiagnosticSink = DiagnosticSink.NONE,
+): Map<FileInputOption, ParseResult.Ok> {
     val parseResults: ParseResults =
         try {
             parseInputs(inputFiles)
@@ -47,6 +54,7 @@ fun parseInputOrFail(inputFiles: List<FileInputOption.File>): Map<FileInputOptio
     if (parseResults.failure.isNotEmpty()) {
         throw GradleException(renderParseFailures(parseResults).joinToString("\n\n"))
     }
+    renderParsedInputs(parseResults.success).forEach(sink::verbose)
     return parseResults.success
 }
 
@@ -55,9 +63,12 @@ fun buildFilterOrFail(
     reporterOption: String?,
     releaseOption: String?,
     tagsOptions: Set<String>,
+    sink: DiagnosticSink = DiagnosticSink.NONE,
 ): VulnlogFilter =
     try {
-        buildFilter(vulnlogFile, reporterOption, releaseOption, tagsOptions)
+        val filter = buildFilter(vulnlogFile, reporterOption, releaseOption, tagsOptions)
+        renderFilterResolution(filter).forEach(sink::verbose)
+        filter
     } catch (e: FilterValidationException) {
         throw GradleException("${e.message}. ${e.detail}")
     }
@@ -65,8 +76,10 @@ fun buildFilterOrFail(
 fun DefaultTask.validateParsedInputOrFailWithFailureOutput(
     fileToResult: Map<FileInputOption, ParseResult.Ok>,
     renderedSeverities: Set<Severity> = setOf(Severity.ERROR),
+    sink: DiagnosticSink = DiagnosticSink.NONE,
 ): ValidationResults {
     val validationFindings = validateFiles(fileToResult)
+    renderValidationSummary(validationFindings).forEach(sink::verbose)
     val rendered = renderValidationFindings(validationFindings, renderedSeverities)
     if (rendered.isNotBlank()) {
         logger.warn(rendered)

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogSuppressTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogSuppressTaskTest.kt
@@ -7,6 +7,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.gradle.testkit.runner.TaskOutcome
 
 private val FILES_FROM_TEST_YAML =
@@ -80,6 +81,39 @@ class VulnlogSuppressTaskTest :
                 val files = outputDir.list()?.toList() ?: emptyList()
                 files shouldContain ".trivyignore.yaml"
                 files.any { it.startsWith("grype") } shouldBe false
+            }
+        }
+
+        context("diagnostics") {
+
+            test("--info shows parsed inputs and written outputs") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to vulnlogYaml())
+
+                val result = runner(dir, "vulnlogSuppress", "--info").build()
+
+                result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.output shouldContain
+                    "parsed test.vl.yaml: schema version 1, releases: 1, tags: 0, vulnerabilities: 1"
+                result.output shouldContain ".trivyignore.yaml: trivy format, 1 entry"
+            }
+
+            test("the default log level hides diagnostics") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to vulnlogYaml())
+
+                val result = runner(dir, "vulnlogSuppress").build()
+
+                result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.output shouldNotContain "parsed test.vl.yaml"
+            }
+
+            test("--info shows entries skipped for the output format") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to vulnlogYaml(reporter = "snyk"))
+
+                val result = runner(dir, "vulnlogSuppress", "--info").build()
+
+                result.task(":vulnlogSuppress")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.output shouldContain
+                    "skipped CVE-2026-1234 for .snyk: the snyk format requires SNYK ids"
             }
         }
 

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/Reporting.kt
@@ -52,6 +52,15 @@ fun collectReportingEntries(
         }.toSet()
 
 /**
+ * Renders one diagnostic line stating how many reporting entries the inputs produced and how many
+ * remain after merging. Shared by the CLI and the Gradle plugin.
+ */
+fun renderReportingCounts(
+    collected: Int,
+    merged: Int,
+): String = "collected $collected report entries, merged to $merged"
+
+/**
  * Merges reporting entries from multiple sources by primary vulnerability ID.
  *
  * Entries with the same primary ID, state, impact, and analysis are merged by unioning

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionCollection.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionCollection.kt
@@ -5,32 +5,53 @@ package dev.vulnlog.lib.core
 
 import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReportEntry
-import dev.vulnlog.lib.model.ReporterType
 import dev.vulnlog.lib.model.Verdict
 import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.model.VulnlogFile
 import dev.vulnlog.lib.model.report.WorkState
 import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
+import dev.vulnlog.lib.result.SuppressionCollectionResult
+import dev.vulnlog.lib.result.SuppressionExclusion
 
 /**
  * Collects and filters suppressed vulnerabilities from a given Vulnlog file based on the specified suppression
- * filter criteria. The vulnerabilities are grouped by their reporter type.
+ * filter criteria. The collected vulnerabilities are grouped by their reporter type. Resolved vulnerabilities
+ * and expired suppressions come back as exclusions; entries that merely fall outside the user-requested
+ * release, tag, or reporter filter do not.
  *
  * @param vulnlogFile The Vulnlog file containing vulnerability records to analyze.
  * @param filter The suppression filter to apply for selecting and grouping vulnerabilities.
- * @return A map where the keys are the reporter types, and the values are lists of suppressed vulnerabilities
- *         associated with each reporter.
+ * @return The suppressed vulnerabilities grouped by reporter type, plus all exclusions.
  */
 fun collectSuppressedVulnerabilities(
     vulnlogFile: VulnlogFile,
     filter: SuppressionFilter,
-): Map<ReporterType, List<SuppressedVulnerability>> =
-    vulnlogFile.vulnerabilities
-        .asSequence()
-        .filterNot { vulnerability -> isResolved(vulnerability, filter.filter.releases) }
-        .flatMap(::explodeOnReports)
-        .applyFilter(filter)
-        .groupBy { it.reporter }
+): SuppressionCollectionResult {
+    val (resolved, unresolved) =
+        vulnlogFile.vulnerabilities.partition { vulnerability -> isResolved(vulnerability, filter.filter.releases) }
+    val (active, expired) =
+        unresolved
+            .asSequence()
+            .flatMap(::explodeOnReports)
+            .applyFilter(filter.filter)
+            .partition { it.isActiveOn(filter.today) }
+    val resolvedExclusions =
+        resolved
+            .asSequence()
+            .flatMap(::explodeOnReports)
+            .applyFilter(filter.filter)
+            .map { SuppressionExclusion.ResolvedVulnerability(it.id) }
+            .toList()
+    return SuppressionCollectionResult(
+        included = active.groupBy { it.reporter },
+        exclusions = (resolvedExclusions + expired.mapNotNull(::expiredExclusion)).distinct(),
+    )
+}
+
+private fun expiredExclusion(suppression: SuppressedVulnerability): SuppressionExclusion? =
+    suppression.expiresAt?.let { expiredAt ->
+        SuppressionExclusion.ExpiredSuppression(suppression.id, suppression.reporter, expiredAt)
+    }
 
 private fun isResolved(
     vulnEntry: VulnerabilityEntry,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionOutputs.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionOutputs.kt
@@ -8,27 +8,59 @@ import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
 import dev.vulnlog.lib.model.suppress.SuppressionFormat
 import dev.vulnlog.lib.model.suppress.SuppressionOutput
 import dev.vulnlog.lib.model.suppress.SuppressionVuln
+import dev.vulnlog.lib.result.SuppressionExclusion
+import dev.vulnlog.lib.result.SuppressionOutputsResult
 import dev.vulnlog.lib.shell.SuppressionFormatRequest
 
 /**
  * Builds the per-reporter suppression outputs for the given target reporters, applying the requested
- * output format. Reporters without a suppressible format (such as [ReporterType.OTHER]) are skipped.
+ * output format. Every entry that does not make it into an output is returned as an exclusion:
+ * entries whose vulnerability id type the format does not support, and entries of reporters without
+ * a suppressible format (such as [ReporterType.OTHER]).
  *
  * @param targetReporters The reporters to generate suppression outputs for.
  * @param reporterToSuppressions The suppressed vulnerabilities grouped by reporter.
  * @param formatRequest The requested output format. Defaults to [SuppressionFormatRequest.Auto].
- * @return A set of [SuppressionOutput] objects, one per suppressible target reporter.
+ * @return The [SuppressionOutput] objects, one per suppressible target reporter, plus all exclusions.
  */
 fun buildSuppressionOutputs(
     targetReporters: Set<ReporterType>,
     reporterToSuppressions: Map<ReporterType, List<SuppressedVulnerability>>,
     formatRequest: SuppressionFormatRequest = SuppressionFormatRequest.Auto,
-): Set<SuppressionOutput> =
-    targetReporters
-        .filterNot { reporter -> reporter == ReporterType.OTHER }
-        .map { reporter -> reporter to resolveFormatRequest(formatRequest, reporter) }
-        .map { (reporter, format) -> createSuppression(format, reporterToSuppressions[reporter]) }
-        .toSet()
+): SuppressionOutputsResult {
+    val (suppressible, unsuppressible) = targetReporters.partition { reporter -> reporter != ReporterType.OTHER }
+    val outputs =
+        suppressible
+            .map { reporter -> reporter to resolveFormatRequest(formatRequest, reporter) }
+            .map { (reporter, format) -> createSuppression(format, reporterToSuppressions[reporter]) }
+    val reporterExclusions = unsupportedReporterExclusions(unsuppressible, reporterToSuppressions)
+    return SuppressionOutputsResult(
+        outputs = outputs.map(OutputWithExclusions::output).toSet(),
+        exclusions = (outputs.flatMap(OutputWithExclusions::exclusions) + reporterExclusions).distinct(),
+    )
+}
+
+private data class OutputWithExclusions(
+    val output: SuppressionOutput,
+    val exclusions: List<SuppressionExclusion>,
+)
+
+private fun unsupportedReporterExclusions(
+    reporters: List<ReporterType>,
+    reporterToSuppressions: Map<ReporterType, List<SuppressedVulnerability>>,
+): List<SuppressionExclusion> =
+    reporters.flatMap { reporter ->
+        reporterToSuppressions[reporter].orEmpty().map { suppression ->
+            SuppressionExclusion.UnsupportedReporter(suppression.id, reporter)
+        }
+    }
+
+private fun unsupportedIdExclusions(
+    unsupported: List<SuppressedVulnerability>,
+    fileName: String,
+    format: SuppressionFormat,
+): List<SuppressionExclusion> =
+    unsupported.map { suppression -> SuppressionExclusion.UnsupportedIdType(suppression.id, fileName, format) }
 
 private fun resolveFormatRequest(
     format: SuppressionFormatRequest,
@@ -50,78 +82,48 @@ private fun nativeFormat(reporter: ReporterType): SuppressionFormat.NativeFormat
 private fun createSuppression(
     format: SuppressionFormat,
     suppressions: List<SuppressedVulnerability>?,
-): SuppressionOutput {
-    val suppressionEntries = suppressions ?: emptyList()
-    return when (format) {
-        is SuppressionFormat.GenericFormat.Generic -> createGenericSuppression(format, suppressionEntries)
-        is SuppressionFormat.NativeFormat.Trivy -> createTrivySuppression(format, suppressionEntries)
-        is SuppressionFormat.NativeFormat.Snyk -> createSnykSuppression(format, suppressionEntries)
-        is SuppressionFormat.NativeFormat.CargoAudit -> createCargoAuditSuppression(format, suppressionEntries)
-    }
+): OutputWithExclusions {
+    val (supported, unsupported) = suppressions.orEmpty().partition { it.id::class in format.vulnIdTypes }
+    val output =
+        when (format) {
+            is SuppressionFormat.GenericFormat.Generic ->
+                SuppressionOutput.GenericSuppression(
+                    fileName = format.reporter.canonical() + ".generic.json",
+                    entries = supported.map(::toGenericEntry).toSet(),
+                )
+
+            is SuppressionFormat.NativeFormat.Trivy ->
+                SuppressionOutput.TrivySuppression(entries = supported.map(::toTrivyEntry).toSet())
+
+            is SuppressionFormat.NativeFormat.Snyk ->
+                SuppressionOutput.SnykSuppression(entries = supported.map(::toSnykEntry).toSet())
+
+            is SuppressionFormat.NativeFormat.CargoAudit ->
+                SuppressionOutput.CargoAuditSuppression(entries = supported.map(::toCargoAuditEntry).toSet())
+        }
+    return OutputWithExclusions(output, unsupportedIdExclusions(unsupported, output.fileName, format))
 }
 
-private fun createGenericSuppression(
-    format: SuppressionFormat.GenericFormat.Generic,
-    suppressions: List<SuppressedVulnerability>,
-): SuppressionOutput {
-    val entries =
-        suppressions
-            .filter { suppression -> suppression.id::class in format.vulnIdTypes }
-            .map { suppression ->
-                SuppressionVuln.GenericSuppressionEntry(
-                    id = suppression.id,
-                    expiresAt = suppression.expiresAt,
-                    reason = suppression.analysis,
-                )
-            }.toSet()
-    return SuppressionOutput.GenericSuppression(
-        fileName = format.reporter.canonical() + ".generic.json",
-        entries = entries,
+private fun toGenericEntry(suppression: SuppressedVulnerability) =
+    SuppressionVuln.GenericSuppressionEntry(
+        id = suppression.id,
+        expiresAt = suppression.expiresAt,
+        reason = suppression.analysis,
     )
-}
 
-private fun createTrivySuppression(
-    format: SuppressionFormat.NativeFormat.Trivy,
-    suppressions: List<SuppressedVulnerability>,
-): SuppressionOutput {
-    val entries =
-        suppressions
-            .filter { suppression -> suppression.id::class in format.vulnIdTypes }
-            .map { suppression ->
-                SuppressionVuln.TrivySuppressionEntry(
-                    id = suppression.id,
-                    expiresAt = suppression.expiresAt,
-                    reason = suppression.analysis,
-                )
-            }.toSet()
-    return SuppressionOutput.TrivySuppression(entries = entries)
-}
+private fun toTrivyEntry(suppression: SuppressedVulnerability) =
+    SuppressionVuln.TrivySuppressionEntry(
+        id = suppression.id,
+        expiresAt = suppression.expiresAt,
+        reason = suppression.analysis,
+    )
 
-private fun createCargoAuditSuppression(
-    format: SuppressionFormat.NativeFormat.CargoAudit,
-    suppressions: List<SuppressedVulnerability>,
-): SuppressionOutput {
-    val entries =
-        suppressions
-            .filter { suppression -> suppression.id::class in format.vulnIdTypes }
-            .map { suppression -> SuppressionVuln.CargoAuditSuppressionEntry(id = suppression.id) }
-            .toSet()
-    return SuppressionOutput.CargoAuditSuppression(entries = entries)
-}
+private fun toSnykEntry(suppression: SuppressedVulnerability) =
+    SuppressionVuln.SnykSuppressionEntry(
+        id = suppression.id,
+        expiresAt = suppression.expiresAt,
+        reason = suppression.analysis,
+    )
 
-private fun createSnykSuppression(
-    format: SuppressionFormat.NativeFormat.Snyk,
-    suppressions: List<SuppressedVulnerability>,
-): SuppressionOutput {
-    val entries =
-        suppressions
-            .filter { suppression -> suppression.id::class in format.vulnIdTypes }
-            .map { suppression ->
-                SuppressionVuln.SnykSuppressionEntry(
-                    id = suppression.id,
-                    expiresAt = suppression.expiresAt,
-                    reason = suppression.analysis,
-                )
-            }.toSet()
-    return SuppressionOutput.SnykSuppression(entries = entries)
-}
+private fun toCargoAuditEntry(suppression: SuppressedVulnerability) =
+    SuppressionVuln.CargoAuditSuppressionEntry(id = suppression.id)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionRenderer.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/SuppressionRenderer.kt
@@ -1,0 +1,86 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core
+
+import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
+import dev.vulnlog.lib.model.suppress.SuppressionFormat
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.result.SuppressionExclusion
+import kotlin.reflect.KClass
+
+/**
+ * Renders one diagnostic line for a written suppression output, stating the target, the format,
+ * and the number of entries. Shared by the CLI and the Gradle plugin.
+ */
+fun renderSuppressionWritten(
+    target: String,
+    output: SuppressionOutput,
+): String = "wrote $target: ${formatName(output)} format, ${pluralizeEntries(output.entries.size)}"
+
+/**
+ * Renders one diagnostic line per entry included in the suppression outputs, the counterpart of
+ * [renderSuppressionExclusion]. Shared by the CLI and the Gradle plugin.
+ */
+fun renderSuppressionInclusions(included: Map<ReporterType, List<SuppressedVulnerability>>): List<String> =
+    included
+        .flatMap { (reporter, suppressions) ->
+            suppressions.map { suppression ->
+                val expiry = suppression.expiresAt?.let { " (expires $it)" } ?: ""
+                "included ${suppression.id.canonical()} for reporter ${reporter.canonical()}$expiry"
+            }
+        }.sorted()
+
+/**
+ * Renders one diagnostic line for an entry excluded from a suppression output, stating what was
+ * skipped and why. Shared by the CLI and the Gradle plugin.
+ */
+fun renderSuppressionExclusion(exclusion: SuppressionExclusion): String =
+    when (exclusion) {
+        is SuppressionExclusion.UnsupportedIdType ->
+            "skipped ${exclusion.id.canonical()} for ${exclusion.fileName}: " +
+                "the ${formatName(exclusion.format)} format requires ${requiredIdTypes(exclusion.format)} ids"
+
+        is SuppressionExclusion.UnsupportedReporter ->
+            "skipped ${exclusion.id.canonical()} for reporter ${exclusion.reporter.canonical()}: " +
+                "no suppression format available"
+
+        is SuppressionExclusion.ResolvedVulnerability ->
+            "skipped ${exclusion.id.canonical()}: resolved vulnerabilities are not suppressed"
+
+        is SuppressionExclusion.ExpiredSuppression ->
+            "skipped ${exclusion.id.canonical()} for reporter ${exclusion.reporter.canonical()}: " +
+                "suppression expired on ${exclusion.expiredAt}"
+    }
+
+private fun formatName(format: SuppressionFormat): String =
+    when (format) {
+        is SuppressionFormat.GenericFormat.Generic -> "generic"
+        SuppressionFormat.NativeFormat.Trivy -> "trivy"
+        SuppressionFormat.NativeFormat.Snyk -> "snyk"
+        SuppressionFormat.NativeFormat.CargoAudit -> "cargo-audit"
+    }
+
+private fun requiredIdTypes(format: SuppressionFormat): String =
+    format.vulnIdTypes.joinToString(" or ") { idTypeName(it) }
+
+private fun idTypeName(type: KClass<out VulnId>): String =
+    when (type) {
+        VulnId.Cve::class -> "CVE"
+        VulnId.Ghsa::class -> "GHSA"
+        VulnId.RustSec::class -> "RUSTSEC"
+        VulnId.Snyk::class -> "SNYK"
+        else -> type.simpleName ?: "unknown"
+    }
+
+private fun formatName(output: SuppressionOutput): String =
+    when (output) {
+        is SuppressionOutput.GenericSuppression -> "generic"
+        is SuppressionOutput.TrivySuppression -> "trivy"
+        is SuppressionOutput.SnykSuppression -> "snyk"
+        is SuppressionOutput.CargoAuditSuppression -> "cargo-audit"
+    }
+
+private fun pluralizeEntries(count: Int): String = if (count == 1) "1 entry" else "$count entries"

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/VulnlogFilter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/VulnlogFilter.kt
@@ -26,9 +26,9 @@ fun Sequence<VulnerabilityEntry>.applyFilter(filter: VulnlogFilter): Sequence<Vu
         .filter { filter.releases.isEmpty() || it.releases.any { release -> release in filter.releases } }
         .filter { filter.tags.isEmpty() || filter.tags.any { tag -> it.tags.contains(tag) } }
 
-fun Sequence<SuppressedVulnerability>.applyFilter(filter: SuppressionFilter): Sequence<SuppressedVulnerability> =
+@JvmName("applyFilterToSuppressedVulnerabilities")
+fun Sequence<SuppressedVulnerability>.applyFilter(filter: VulnlogFilter): Sequence<SuppressedVulnerability> =
     this
-        .filter { filter.filter.releases.isEmpty() || it.releases.any { release -> release in filter.filter.releases } }
-        .filter { filter.filter.tags.isEmpty() || filter.filter.tags.any { tag -> it.tags.contains(tag) } }
-        .filter { filter.filter.reporter == null || filter.filter.reporter == it.reporter }
-        .filter { it.isActiveOn(filter.today) }
+        .filter { filter.releases.isEmpty() || it.releases.any { release -> release in filter.releases } }
+        .filter { filter.tags.isEmpty() || filter.tags.any { tag -> it.tags.contains(tag) } }
+        .filter { filter.reporter == null || filter.reporter == it.reporter }

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/SuppressedVulnerability.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/suppress/SuppressedVulnerability.kt
@@ -21,24 +21,27 @@ data class SuppressedVulnerability(
 }
 
 sealed interface SuppressionOutput {
+    val fileName: String
+    val entries: Set<SuppressionVuln>
+
     data class GenericSuppression(
-        val fileName: String = "generic.json",
-        val entries: Set<SuppressionVuln.GenericSuppressionEntry>,
+        override val fileName: String = "generic.json",
+        override val entries: Set<SuppressionVuln.GenericSuppressionEntry>,
     ) : SuppressionOutput
 
     data class TrivySuppression(
-        val fileName: String = ".trivyignore.yaml",
-        val entries: Set<SuppressionVuln.TrivySuppressionEntry>,
+        override val fileName: String = ".trivyignore.yaml",
+        override val entries: Set<SuppressionVuln.TrivySuppressionEntry>,
     ) : SuppressionOutput
 
     data class SnykSuppression(
-        val fileName: String = ".snyk",
-        val entries: Set<SuppressionVuln.SnykSuppressionEntry>,
+        override val fileName: String = ".snyk",
+        override val entries: Set<SuppressionVuln.SnykSuppressionEntry>,
     ) : SuppressionOutput
 
     data class CargoAuditSuppression(
-        val fileName: String = "audit.toml",
-        val entries: Set<SuppressionVuln.CargoAuditSuppressionEntry>,
+        override val fileName: String = "audit.toml",
+        override val entries: Set<SuppressionVuln.CargoAuditSuppressionEntry>,
     ) : SuppressionOutput
 }
 

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/result/SuppressionResult.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/result/SuppressionResult.kt
@@ -1,0 +1,50 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.result
+
+import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
+import dev.vulnlog.lib.model.suppress.SuppressionFormat
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import java.time.LocalDate
+
+/**
+ * A suppression entry excluded from an output, carrying the data needed to explain why. The
+ * shells decide whether to render exclusions as diagnostics or warnings.
+ */
+sealed interface SuppressionExclusion {
+    val id: VulnId
+
+    data class UnsupportedIdType(
+        override val id: VulnId,
+        val fileName: String,
+        val format: SuppressionFormat,
+    ) : SuppressionExclusion
+
+    data class UnsupportedReporter(
+        override val id: VulnId,
+        val reporter: ReporterType,
+    ) : SuppressionExclusion
+
+    data class ResolvedVulnerability(
+        override val id: VulnId,
+    ) : SuppressionExclusion
+
+    data class ExpiredSuppression(
+        override val id: VulnId,
+        val reporter: ReporterType,
+        val expiredAt: LocalDate,
+    ) : SuppressionExclusion
+}
+
+data class SuppressionOutputsResult(
+    val outputs: Set<SuppressionOutput>,
+    val exclusions: List<SuppressionExclusion>,
+)
+
+data class SuppressionCollectionResult(
+    val included: Map<ReporterType, List<SuppressedVulnerability>>,
+    val exclusions: List<SuppressionExclusion>,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/Diagnostics.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/Diagnostics.kt
@@ -1,0 +1,29 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.shell
+
+/**
+ * Receiver for optional diagnostic events. Shells install a sink that filters by the requested
+ * verbosity and writes to their own output channel; [NONE] discards everything.
+ */
+fun interface DiagnosticSink {
+    fun accept(event: DiagnosticEvent)
+
+    fun verbose(message: String) = accept(DiagnosticEvent(DiagnosticLevel.VERBOSE, message))
+
+    fun debug(message: String) = accept(DiagnosticEvent(DiagnosticLevel.DEBUG, message))
+
+    companion object {
+        val NONE: DiagnosticSink = DiagnosticSink { }
+    }
+}
+
+data class DiagnosticEvent(
+    val level: DiagnosticLevel,
+    val message: String,
+)
+
+enum class DiagnosticLevel { VERBOSE, DEBUG }
+
+fun renderDiagnostic(event: DiagnosticEvent): String = "${event.level.name.lowercase()}: ${event.message}"

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/FilterValidation.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/FilterValidation.kt
@@ -122,6 +122,21 @@ fun buildFilter(
         reporter = resolveReporterFilter(reporterOption),
     )
 
+/**
+ * Renders one diagnostic line per active filter dimension, stating what the filter resolved to.
+ * Inactive dimensions produce no line.
+ */
+fun renderFilterResolution(filter: VulnlogFilter): List<String> =
+    listOfNotNull(
+        filter.releases
+            .takeIf { it.isNotEmpty() }
+            ?.let { releases -> "release filter expanded to releases: ${releases.joinToString(", ") { it.value }}" },
+        filter.tags
+            .takeIf { it.isNotEmpty() }
+            ?.let { tags -> "tag filter matched tags: ${tags.joinToString(", ") { it.value }}" },
+        filter.reporter?.let { reporter -> "reporter filter: ${reporter.canonical()}" },
+    )
+
 class FilterValidationException(
     message: String,
     val detail: String,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/ParseFile.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/ParseFile.kt
@@ -4,6 +4,8 @@
 package dev.vulnlog.lib.shell
 
 import dev.vulnlog.lib.core.renderParseFailure
+import dev.vulnlog.lib.core.shortenSchemaVersion
+import dev.vulnlog.lib.model.VulnlogFile
 import dev.vulnlog.lib.model.VulnlogFileRaw
 import dev.vulnlog.lib.parse.createYamlMapper
 import dev.vulnlog.lib.parse.parseVulnlogFile
@@ -45,6 +47,23 @@ fun parseInputs(inputs: List<FileInputOption>): ParseResults {
  */
 fun renderParseFailures(parseResults: ParseResults): List<String> =
     parseResults.failure.map { (input, result) -> renderParseFailure(input.sourceFile().name, result) }
+
+/**
+ * Renders one diagnostic line per successfully parsed input, stating the detected schema version
+ * and the entry counts. Shared by the CLI and the Gradle plugin so verbose output never drifts.
+ */
+fun renderParsedInputs(success: Map<FileInputOption, ParseResult.Ok>): List<String> =
+    success.entries
+        .map { (input, result) -> renderParsedInput(input.sourceFile().name, result.content) }
+        .sorted()
+
+private fun renderParsedInput(
+    name: String,
+    content: VulnlogFile,
+): String =
+    "parsed $name: schema version ${shortenSchemaVersion(content.schemaVersion)}, " +
+        "releases: ${content.releases.size}, tags: ${content.tags.size}, " +
+        "vulnerabilities: ${content.vulnerabilities.size}"
 
 private fun parseInput(
     mapper: ObjectMapper,

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/ValidateFile.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/shell/ValidateFile.kt
@@ -8,6 +8,7 @@ import dev.vulnlog.lib.core.renderValidation
 import dev.vulnlog.lib.core.validate
 import dev.vulnlog.lib.result.ParseResult
 import dev.vulnlog.lib.result.Severity
+import dev.vulnlog.lib.result.ValidationResult
 import dev.vulnlog.lib.result.ValidationResults
 
 /** Runs the domain rules over every file and returns the findings as data, keyed by input. */
@@ -23,6 +24,34 @@ fun validateFiles(fileToResult: Map<FileInputOption, ParseResult.Ok>): Validatio
         }
     val results = validate(contexts.values.toList())
     return ValidationResults(contexts.mapValues { (_, context) -> results.getValue(context) })
+}
+
+/**
+ * Renders one diagnostic line per validated file, stating the finding counts per severity. Shows
+ * counts of findings the default output suppresses, such as warnings outside strict mode.
+ */
+fun renderValidationSummary(results: ValidationResults): List<String> =
+    results.fileFindings
+        .map { (input, result) -> renderValidationSummaryLine(input.sourceFile().name, result) }
+        .sorted()
+
+private fun renderValidationSummaryLine(
+    name: String,
+    result: ValidationResult,
+): String {
+    val counts =
+        listOfNotNull(
+            result.errors.size
+                .takeIf { it > 0 }
+                ?.let { "$it error(s)" },
+            result.warnings.size
+                .takeIf { it > 0 }
+                ?.let { "$it warning(s)" },
+            result.infos.size
+                .takeIf { it > 0 }
+                ?.let { "$it info(s)" },
+        ).joinToString(", ")
+    return "validated $name: ${counts.ifEmpty { "no findings" }}"
 }
 
 /** Renders the findings of the given severities, one block per file, same format on all surfaces. */

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/ReportingTest.kt
@@ -427,4 +427,12 @@ class ReportingTest :
                 result shouldBe defaultProject
             }
         }
+
+        context("renderReportingCounts") {
+
+            test("states the collected and merged counts") {
+                renderReportingCounts(collected = 12, merged = 9) shouldBe
+                    "collected 12 report entries, merged to 9"
+            }
+        }
     })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionCollectionTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionCollectionTest.kt
@@ -18,6 +18,7 @@ import dev.vulnlog.lib.model.VexJustification
 import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.model.VulnerabilityEntry
 import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.result.SuppressionExclusion
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.shouldBeEmpty
@@ -84,7 +85,7 @@ class SuppressionCollectionTest :
             test("collects vulnerability with suppressed report") {
                 val file = emptyFile().copy(vulnerabilities = listOf(vulnerability()))
                 val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
                 result[ReporterType.TRIVY]!! shouldHaveSize 1
@@ -96,7 +97,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
                 val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -111,7 +112,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
-                val result = collectSuppressedVulnerabilities(file, filter)
+                val result = collectSuppressedVulnerabilities(file, filter).included
 
                 result[ReporterType.TRIVY]!! shouldHaveSize 1
                 result[ReporterType.TRIVY]!![0].id shouldBe VulnId.Cve("CVE-2024-0002")
@@ -136,7 +137,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
-                val result = collectSuppressedVulnerabilities(file, filter)
+                val result = collectSuppressedVulnerabilities(file, filter).included
 
                 result[ReporterType.TRIVY]!! shouldHaveSize 2
                 result[ReporterType.TRIVY]!![0].id shouldBe VulnId.Cve("CVE-2024-0002")
@@ -149,7 +150,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln1, vuln2))
 
                 val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
-                val result = collectSuppressedVulnerabilities(file, filter)
+                val result = collectSuppressedVulnerabilities(file, filter).included
 
                 result[ReporterType.TRIVY]!! shouldHaveSize 1
                 result[ReporterType.TRIVY]!!.first().id shouldBe VulnId.Cve("CVE-2024-0001")
@@ -166,7 +167,7 @@ class SuppressionCollectionTest :
                     collectSuppressedVulnerabilities(
                         file,
                         SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1, releaseV2)), today),
-                    )
+                    ).included
 
                 result[ReporterType.TRIVY]!! shouldHaveSize 2
             }
@@ -179,6 +180,7 @@ class SuppressionCollectionTest :
 
                 val result =
                     collectSuppressedVulnerabilities(file, SuppressionFilter(VulnlogFilter(tags = setOf(tag)), today))
+                        .included
 
                 result[ReporterType.TRIVY]!! shouldHaveSize 1
                 result[ReporterType.TRIVY]!!.first().id shouldBe VulnId.Cve("CVE-2024-0001")
@@ -194,7 +196,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -209,7 +211,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
-                val result = collectSuppressedVulnerabilities(file, filter)
+                val result = collectSuppressedVulnerabilities(file, filter).included
 
                 result[ReporterType.TRIVY]!! shouldHaveSize 1
                 result[ReporterType.TRIVY]!!.first().id shouldBe VulnId.Cve("CVE-2024-0001")
@@ -225,7 +227,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1, releaseV2)), today)
-                val result = collectSuppressedVulnerabilities(file, filter)
+                val result = collectSuppressedVulnerabilities(file, filter).included
 
                 result.shouldBeEmpty()
             }
@@ -235,7 +237,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -247,7 +249,7 @@ class SuppressionCollectionTest :
                     val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                     val result =
-                        collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                        collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                     result.shouldBeEmpty()
                 }
@@ -260,7 +262,7 @@ class SuppressionCollectionTest :
                     val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                     val result =
-                        collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                        collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                     result shouldHaveSize 1
                 }
@@ -276,7 +278,7 @@ class SuppressionCollectionTest :
                     collectSuppressedVulnerabilities(
                         file,
                         SuppressionFilter(VulnlogFilter(reporter = ReporterType.TRIVY), today),
-                    )
+                    ).included
 
                 result shouldHaveSize 1
                 result.keys.first() shouldBe ReporterType.TRIVY
@@ -289,7 +291,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val result =
-                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                    collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 2
             }
@@ -306,7 +308,7 @@ class SuppressionCollectionTest :
                     )
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -319,7 +321,7 @@ class SuppressionCollectionTest :
                     )
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -333,7 +335,7 @@ class SuppressionCollectionTest :
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
                 val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
-                val result = collectSuppressedVulnerabilities(file, filter)
+                val result = collectSuppressedVulnerabilities(file, filter).included
 
                 result shouldHaveSize 1
             }
@@ -346,7 +348,7 @@ class SuppressionCollectionTest :
                     )
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -359,7 +361,7 @@ class SuppressionCollectionTest :
                     )
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -368,7 +370,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(verdict = Verdict.Affected(Severity.HIGH))
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -378,7 +380,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(reports = listOf(report), verdict = Verdict.Affected(Severity.HIGH))
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -387,7 +389,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(verdict = Verdict.RiskAcceptable(Severity.MEDIUM))
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -397,7 +399,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(reports = listOf(report), verdict = Verdict.RiskAcceptable(Severity.MEDIUM))
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -406,7 +408,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(verdict = Verdict.UnderInvestigation)
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -416,7 +418,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -430,7 +432,7 @@ class SuppressionCollectionTest :
                     )
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -440,7 +442,7 @@ class SuppressionCollectionTest :
                 val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -454,7 +456,7 @@ class SuppressionCollectionTest :
                     )
                 val file = emptyFile().copy(vulnerabilities = listOf(vuln))
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 0
             }
@@ -463,7 +465,7 @@ class SuppressionCollectionTest :
         context("collectSuppressedVulnerabilities with no filters") {
 
             test("returns empty map for file with no vulnerabilities") {
-                val result = collectSuppressedVulnerabilities(emptyFile(), SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(emptyFile(), SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -481,7 +483,7 @@ class SuppressionCollectionTest :
                             ),
                     )
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result.shouldBeEmpty()
             }
@@ -493,7 +495,7 @@ class SuppressionCollectionTest :
                         vulnerabilities = listOf(vulnerability(reports = listOf(report))),
                     )
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 1
             }
@@ -506,11 +508,111 @@ class SuppressionCollectionTest :
                         vulnerabilities = listOf(vulnerability(reports = listOf(report1, report2))),
                     )
 
-                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today)).included
 
                 result shouldHaveSize 2
                 result[ReporterType.TRIVY]!! shouldHaveSize 1
                 result[ReporterType.SNYK]!! shouldHaveSize 1
+            }
+        }
+
+        context("collection exclusions") {
+
+            test("resolved vulnerabilities are reported as exclusions") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV1),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+
+                result.exclusions shouldBe
+                    listOf(SuppressionExclusion.ResolvedVulnerability(VulnId.Cve("CVE-2024-0001")))
+            }
+
+            test("expired suppressions are reported as exclusions with the expiry date") {
+                val expiredAt = today.minusDays(1)
+                val report = trivyReport(suppress = Suppression(expiresAt = expiredAt))
+                val vuln = vulnerability(reports = listOf(report), verdict = Verdict.UnderInvestigation)
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+
+                result.included.shouldBeEmpty()
+                result.exclusions shouldBe
+                    listOf(
+                        SuppressionExclusion.ExpiredSuppression(
+                            VulnId.Cve("CVE-2024-0001"),
+                            ReporterType.TRIVY,
+                            expiredAt,
+                        ),
+                    )
+            }
+
+            test("included entries produce no exclusions") {
+                val file = emptyFile().copy(vulnerabilities = listOf(vulnerability()))
+
+                val result = collectSuppressedVulnerabilities(file, SuppressionFilter(today = today))
+
+                result.exclusions shouldBe emptyList()
+            }
+
+            test("entries outside the requested filter are not exclusions") {
+                val vuln = vulnerability(releases = listOf(releaseV2))
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(releases = setOf(releaseV1)), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result.included.shouldBeEmpty()
+                result.exclusions shouldBe emptyList()
+            }
+
+            test("resolved vulnerabilities inside the requested reporter filter are exclusions") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV1),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(reporter = ReporterType.TRIVY), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result.exclusions shouldBe
+                    listOf(SuppressionExclusion.ResolvedVulnerability(VulnId.Cve("CVE-2024-0001")))
+            }
+
+            test("resolved vulnerabilities outside the requested reporter filter are not exclusions") {
+                val vuln =
+                    vulnerability(
+                        reports = listOf(report(reporter = ReporterType.SNYK)),
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV1),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(reporter = ReporterType.TRIVY), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result.included.shouldBeEmpty()
+                result.exclusions shouldBe emptyList()
+            }
+
+            test("resolved vulnerabilities outside the requested tag filter are not exclusions") {
+                val vuln =
+                    vulnerability(
+                        verdict = Verdict.Affected(Severity.HIGH),
+                        resolution = Resolution(release = releaseV1),
+                    )
+                val file = emptyFile().copy(vulnerabilities = listOf(vuln))
+
+                val filter = SuppressionFilter(VulnlogFilter(tags = setOf(Tag("backend"))), today)
+                val result = collectSuppressedVulnerabilities(file, filter)
+
+                result.exclusions shouldBe emptyList()
             }
         }
     })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionOutputsTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionOutputsTest.kt
@@ -7,7 +7,9 @@ import dev.vulnlog.lib.model.Release
 import dev.vulnlog.lib.model.ReporterType
 import dev.vulnlog.lib.model.VulnId
 import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
+import dev.vulnlog.lib.model.suppress.SuppressionFormat
 import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.result.SuppressionExclusion
 import dev.vulnlog.lib.shell.SuppressionFormatRequest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -40,7 +42,7 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln()
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input).outputs
 
                 result shouldHaveSize 1
                 result.first().shouldBeInstanceOf<SuppressionOutput.TrivySuppression>()
@@ -50,7 +52,7 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln(reporter = ReporterType.OTHER)
                 val input = mapOf(ReporterType.OTHER to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.OTHER), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.OTHER), input).outputs
 
                 result.shouldBeEmpty()
             }
@@ -59,7 +61,7 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-1234"), analysis = "false positive")
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input).outputs
                 val trivy = result.first() as SuppressionOutput.TrivySuppression
 
                 trivy.entries shouldHaveSize 1
@@ -68,7 +70,7 @@ class SuppressionOutputsTest :
             }
 
             test("produces empty TrivySuppression when no suppressions match") {
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), emptyMap())
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), emptyMap()).outputs
 
                 result shouldHaveSize 1
                 val trivy = result.first() as SuppressionOutput.TrivySuppression
@@ -76,14 +78,14 @@ class SuppressionOutputsTest :
             }
 
             test("ignores target reporters not in suppressable set") {
-                val result = buildSuppressionOutputs(setOf(ReporterType.OTHER, ReporterType.TRIVY), emptyMap())
+                val result = buildSuppressionOutputs(setOf(ReporterType.OTHER, ReporterType.TRIVY), emptyMap()).outputs
 
                 result shouldHaveSize 1
                 result.first().shouldBeInstanceOf<SuppressionOutput.TrivySuppression>()
             }
 
             test("produces empty output when no target reporters") {
-                val result = buildSuppressionOutputs(emptySet(), emptyMap())
+                val result = buildSuppressionOutputs(emptySet(), emptyMap()).outputs
 
                 result.shouldBeEmpty()
             }
@@ -93,7 +95,7 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln(expiresAt = expiresAt)
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input).outputs
                 val trivy = result.first() as SuppressionOutput.TrivySuppression
 
                 trivy.entries.first().expiresAt shouldBe expiresAt
@@ -103,7 +105,7 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln(expiresAt = null)
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input).outputs
                 val trivy = result.first() as SuppressionOutput.TrivySuppression
 
                 trivy.entries.first().expiresAt shouldBe null
@@ -114,7 +116,7 @@ class SuppressionOutputsTest :
                 val entry2 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"))
                 val input = mapOf(ReporterType.TRIVY to listOf(entry1, entry2))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input).outputs
                 val trivy = result.first() as SuppressionOutput.TrivySuppression
 
                 trivy.entries shouldHaveSize 1
@@ -127,7 +129,7 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln(id = VulnId.Snyk("SNYK-JAVA-001"), reporter = ReporterType.SNYK)
                 val input = mapOf(ReporterType.SNYK to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input).outputs
 
                 result shouldHaveSize 1
                 result.first().shouldBeInstanceOf<SuppressionOutput.SnykSuppression>()
@@ -142,7 +144,7 @@ class SuppressionOutputsTest :
                     )
                 val input = mapOf(ReporterType.SNYK to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input).outputs
                 val snyk = result.first() as SuppressionOutput.SnykSuppression
 
                 snyk.entries shouldHaveSize 1
@@ -154,14 +156,14 @@ class SuppressionOutputsTest :
                 val cveEntry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), reporter = ReporterType.SNYK)
                 val input = mapOf(ReporterType.SNYK to listOf(cveEntry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input).outputs
                 val snyk = result.first() as SuppressionOutput.SnykSuppression
 
                 snyk.entries.shouldBeEmpty()
             }
 
             test("produces empty SnykSuppression when no suppressions match") {
-                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), emptyMap())
+                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), emptyMap()).outputs
 
                 result shouldHaveSize 1
                 val snyk = result.first() as SuppressionOutput.SnykSuppression
@@ -178,7 +180,7 @@ class SuppressionOutputsTest :
                     )
                 val input = mapOf(ReporterType.SNYK to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input)
+                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input).outputs
                 val snyk = result.first() as SuppressionOutput.SnykSuppression
 
                 snyk.entries.first().expiresAt shouldBe expiresAt
@@ -188,7 +190,7 @@ class SuppressionOutputsTest :
         context("buildSuppressionOutputs for multiple reporters") {
 
             test("produces both trivy and snyk output") {
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY, ReporterType.SNYK), emptyMap())
+                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY, ReporterType.SNYK), emptyMap()).outputs
 
                 result shouldHaveSize 2
             }
@@ -199,7 +201,8 @@ class SuppressionOutputsTest :
             test("auto keeps the native format for a native reporter") {
                 val input = mapOf(ReporterType.TRIVY to listOf(suppressedVuln()))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input, SuppressionFormatRequest.Auto)
+                val result =
+                    buildSuppressionOutputs(setOf(ReporterType.TRIVY), input, SuppressionFormatRequest.Auto).outputs
 
                 result.first().shouldBeInstanceOf<SuppressionOutput.TrivySuppression>()
             }
@@ -207,7 +210,8 @@ class SuppressionOutputsTest :
             test("auto falls back to generic for a reporter without a native format") {
                 val input = mapOf(ReporterType.GRYPE to listOf(suppressedVuln(reporter = ReporterType.GRYPE)))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.GRYPE), input, SuppressionFormatRequest.Auto)
+                val result =
+                    buildSuppressionOutputs(setOf(ReporterType.GRYPE), input, SuppressionFormatRequest.Auto).outputs
 
                 val generic = result.first().shouldBeInstanceOf<SuppressionOutput.GenericSuppression>()
                 generic.fileName shouldBe "grype.generic.json"
@@ -221,7 +225,7 @@ class SuppressionOutputsTest :
                         SuppressionFormatRequest.Generic,
                     )
 
-                val generic = result.first().shouldBeInstanceOf<SuppressionOutput.GenericSuppression>()
+                val generic = result.outputs.first().shouldBeInstanceOf<SuppressionOutput.GenericSuppression>()
                 generic.fileName shouldBe "github-dependabot.generic.json"
             }
 
@@ -229,7 +233,8 @@ class SuppressionOutputsTest :
                 val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-1234"), analysis = "false positive")
                 val input = mapOf(ReporterType.TRIVY to listOf(entry))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.TRIVY), input, SuppressionFormatRequest.Generic)
+                val result =
+                    buildSuppressionOutputs(setOf(ReporterType.TRIVY), input, SuppressionFormatRequest.Generic).outputs
 
                 val generic = result.first().shouldBeInstanceOf<SuppressionOutput.GenericSuppression>()
                 generic.fileName shouldBe "trivy.generic.json"
@@ -244,6 +249,7 @@ class SuppressionOutputsTest :
 
                 val native =
                     buildSuppressionOutputs(setOf(ReporterType.CARGO_AUDIT), input, SuppressionFormatRequest.Auto)
+                        .outputs
                 native
                     .first()
                     .shouldBeInstanceOf<SuppressionOutput.CargoAuditSuppression>()
@@ -252,6 +258,7 @@ class SuppressionOutputsTest :
 
                 val generic =
                     buildSuppressionOutputs(setOf(ReporterType.CARGO_AUDIT), input, SuppressionFormatRequest.Generic)
+                        .outputs
                 generic
                     .first()
                     .shouldBeInstanceOf<SuppressionOutput.GenericSuppression>()
@@ -261,7 +268,8 @@ class SuppressionOutputsTest :
             test("excludes the OTHER reporter regardless of requested format") {
                 val input = mapOf(ReporterType.OTHER to listOf(suppressedVuln(reporter = ReporterType.OTHER)))
 
-                val result = buildSuppressionOutputs(setOf(ReporterType.OTHER), input, SuppressionFormatRequest.Generic)
+                val result =
+                    buildSuppressionOutputs(setOf(ReporterType.OTHER), input, SuppressionFormatRequest.Generic).outputs
 
                 result.shouldBeEmpty()
             }
@@ -272,11 +280,57 @@ class SuppressionOutputsTest :
                         setOf(ReporterType.TRIVY, ReporterType.SNYK),
                         emptyMap(),
                         SuppressionFormatRequest.Generic,
-                    )
+                    ).outputs
 
                 result shouldHaveSize 2
                 result.filterIsInstance<SuppressionOutput.GenericSuppression>().map { it.fileName }.toSet() shouldBe
                     setOf("trivy.generic.json", "snyk.generic.json")
+            }
+        }
+
+        context("buildSuppressionOutputs exclusions") {
+
+            test("records a non-snyk id dropped from the snyk output") {
+                val cveEntry = suppressedVuln(id = VulnId.Cve("CVE-2026-1234"), reporter = ReporterType.SNYK)
+                val input = mapOf(ReporterType.SNYK to listOf(cveEntry))
+
+                val result = buildSuppressionOutputs(setOf(ReporterType.SNYK), input)
+
+                result.exclusions shouldBe
+                    listOf(
+                        SuppressionExclusion.UnsupportedIdType(
+                            id = VulnId.Cve("CVE-2026-1234"),
+                            fileName = ".snyk",
+                            format = SuppressionFormat.NativeFormat.Snyk,
+                        ),
+                    )
+            }
+
+            test("records entries of the OTHER reporter") {
+                val entry = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), reporter = ReporterType.OTHER)
+                val input = mapOf(ReporterType.OTHER to listOf(entry))
+
+                val result = buildSuppressionOutputs(setOf(ReporterType.OTHER), input)
+
+                result.outputs.shouldBeEmpty()
+                result.exclusions shouldBe
+                    listOf(
+                        SuppressionExclusion.UnsupportedReporter(VulnId.Cve("CVE-2024-0001"), ReporterType.OTHER),
+                    )
+            }
+
+            test("supported entries produce no exclusions") {
+                val input = mapOf(ReporterType.TRIVY to listOf(suppressedVuln()))
+
+                buildSuppressionOutputs(setOf(ReporterType.TRIVY), input).exclusions.shouldBeEmpty()
+            }
+
+            test("deduplicates identical exclusions") {
+                val entry1 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), reporter = ReporterType.SNYK)
+                val entry2 = suppressedVuln(id = VulnId.Cve("CVE-2024-0001"), reporter = ReporterType.SNYK)
+                val input = mapOf(ReporterType.SNYK to listOf(entry1, entry2))
+
+                buildSuppressionOutputs(setOf(ReporterType.SNYK), input).exclusions shouldHaveSize 1
             }
         }
     })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionRendererTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/SuppressionRendererTest.kt
@@ -1,0 +1,165 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core
+
+import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.suppress.SuppressedVulnerability
+import dev.vulnlog.lib.model.suppress.SuppressionFormat
+import dev.vulnlog.lib.model.suppress.SuppressionOutput
+import dev.vulnlog.lib.model.suppress.SuppressionVuln
+import dev.vulnlog.lib.result.SuppressionExclusion
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class SuppressionRendererTest :
+    FunSpec({
+
+        context("renderSuppressionWritten") {
+
+            test("renders a trivy output with a single entry") {
+                val output =
+                    SuppressionOutput.TrivySuppression(
+                        entries =
+                            setOf(
+                                SuppressionVuln.TrivySuppressionEntry(
+                                    id = VulnId.Cve("CVE-2026-1234"),
+                                    reason = "not reachable",
+                                ),
+                            ),
+                    )
+
+                renderSuppressionWritten("/out/.trivyignore.yaml", output) shouldBe
+                    "wrote /out/.trivyignore.yaml: trivy format, 1 entry"
+            }
+
+            test("pluralizes the entry count") {
+                val output =
+                    SuppressionOutput.GenericSuppression(
+                        entries =
+                            setOf(
+                                SuppressionVuln.GenericSuppressionEntry(
+                                    id = VulnId.Cve("CVE-2026-1234"),
+                                    reason = "not reachable",
+                                ),
+                                SuppressionVuln.GenericSuppressionEntry(
+                                    id = VulnId.Ghsa("GHSA-aaaa-bbbb-cccc"),
+                                    reason = "not reachable",
+                                ),
+                            ),
+                    )
+
+                renderSuppressionWritten("trivy.generic.json", output) shouldBe
+                    "wrote trivy.generic.json: generic format, 2 entries"
+            }
+
+            test("renders an empty snyk output") {
+                val output = SuppressionOutput.SnykSuppression(entries = emptySet())
+
+                renderSuppressionWritten("<stdout>", output) shouldBe "wrote <stdout>: snyk format, 0 entries"
+            }
+
+            test("renders the cargo-audit format name") {
+                val entry = SuppressionVuln.CargoAuditSuppressionEntry(id = VulnId.RustSec("RUSTSEC-2026-0001"))
+                val output = SuppressionOutput.CargoAuditSuppression(entries = setOf(entry))
+
+                renderSuppressionWritten("audit.toml", output) shouldBe
+                    "wrote audit.toml: cargo-audit format, 1 entry"
+            }
+        }
+
+        context("renderSuppressionInclusions") {
+
+            test("renders one sorted line per included entry, with the expiry when present") {
+                val included =
+                    mapOf(
+                        ReporterType.TRIVY to
+                            listOf(
+                                SuppressedVulnerability(
+                                    id = VulnId.Cve("CVE-2026-1234"),
+                                    releases = emptyList(),
+                                    reporter = ReporterType.TRIVY,
+                                    expiresAt = LocalDate.of(2026, 9, 1),
+                                    analysis = "not reachable",
+                                ),
+                            ),
+                        ReporterType.SNYK to
+                            listOf(
+                                SuppressedVulnerability(
+                                    id = VulnId.Cve("CVE-2026-0002"),
+                                    releases = emptyList(),
+                                    reporter = ReporterType.SNYK,
+                                    expiresAt = null,
+                                    analysis = "not reachable",
+                                ),
+                            ),
+                    )
+
+                renderSuppressionInclusions(included) shouldBe
+                    listOf(
+                        "included CVE-2026-0002 for reporter snyk",
+                        "included CVE-2026-1234 for reporter trivy (expires 2026-09-01)",
+                    )
+            }
+
+            test("renders nothing when nothing was included") {
+                renderSuppressionInclusions(emptyMap()) shouldBe emptyList()
+            }
+        }
+
+        context("renderSuppressionExclusion") {
+
+            test("names the file and the required id type for an unsupported id type") {
+                val exclusion =
+                    SuppressionExclusion.UnsupportedIdType(
+                        id = VulnId.Cve("CVE-2026-1234"),
+                        fileName = ".snyk",
+                        format = SuppressionFormat.NativeFormat.Snyk,
+                    )
+
+                renderSuppressionExclusion(exclusion) shouldBe
+                    "skipped CVE-2026-1234 for .snyk: the snyk format requires SNYK ids"
+            }
+
+            test("lists all id types a format accepts") {
+                val exclusion =
+                    SuppressionExclusion.UnsupportedIdType(
+                        id = VulnId.RustSec("RUSTSEC-2026-0001"),
+                        fileName = ".trivyignore.yaml",
+                        format = SuppressionFormat.NativeFormat.Trivy,
+                    )
+
+                renderSuppressionExclusion(exclusion) shouldBe
+                    "skipped RUSTSEC-2026-0001 for .trivyignore.yaml: the trivy format requires CVE or GHSA ids"
+            }
+
+            test("names the reporter for an unsupported reporter") {
+                val exclusion =
+                    SuppressionExclusion.UnsupportedReporter(VulnId.Cve("CVE-2026-1234"), ReporterType.OTHER)
+
+                renderSuppressionExclusion(exclusion) shouldBe
+                    "skipped CVE-2026-1234 for reporter other: no suppression format available"
+            }
+
+            test("explains a resolved vulnerability") {
+                val exclusion = SuppressionExclusion.ResolvedVulnerability(VulnId.Cve("CVE-2026-1234"))
+
+                renderSuppressionExclusion(exclusion) shouldBe
+                    "skipped CVE-2026-1234: resolved vulnerabilities are not suppressed"
+            }
+
+            test("names the expiry date of an expired suppression") {
+                val exclusion =
+                    SuppressionExclusion.ExpiredSuppression(
+                        VulnId.Cve("CVE-2026-1234"),
+                        ReporterType.TRIVY,
+                        LocalDate.of(2026, 1, 31),
+                    )
+
+                renderSuppressionExclusion(exclusion) shouldBe
+                    "skipped CVE-2026-1234 for reporter trivy: suppression expired on 2026-01-31"
+            }
+        }
+    })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/DiagnosticsTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/DiagnosticsTest.kt
@@ -1,0 +1,46 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.shell
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DiagnosticsTest :
+    FunSpec({
+
+        test("NONE discards events") {
+            DiagnosticSink.NONE.verbose("ignored")
+            DiagnosticSink.NONE.debug("ignored")
+        }
+
+        test("verbose builds a verbose event") {
+            val events = mutableListOf<DiagnosticEvent>()
+            val sink = DiagnosticSink(events::add)
+
+            sink.verbose("parsed file")
+
+            events shouldBe listOf(DiagnosticEvent(DiagnosticLevel.VERBOSE, "parsed file"))
+        }
+
+        test("debug builds a debug event") {
+            val events = mutableListOf<DiagnosticEvent>()
+            val sink = DiagnosticSink(events::add)
+
+            sink.debug("timing")
+
+            events shouldBe listOf(DiagnosticEvent(DiagnosticLevel.DEBUG, "timing"))
+        }
+
+        context("renderDiagnostic") {
+
+            test("prefixes verbose events") {
+                renderDiagnostic(DiagnosticEvent(DiagnosticLevel.VERBOSE, "parsed file")) shouldBe
+                    "verbose: parsed file"
+            }
+
+            test("prefixes debug events") {
+                renderDiagnostic(DiagnosticEvent(DiagnosticLevel.DEBUG, "timing")) shouldBe "debug: timing"
+            }
+        }
+    })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/FilterValidationTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/FilterValidationTest.kt
@@ -1,0 +1,54 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.shell
+
+import dev.vulnlog.lib.core.VulnlogFilter
+import dev.vulnlog.lib.model.Release
+import dev.vulnlog.lib.model.ReporterType
+import dev.vulnlog.lib.model.Tag
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FilterValidationTest :
+    FunSpec({
+
+        context("renderFilterResolution") {
+
+            test("renders nothing for an empty filter") {
+                val filter = VulnlogFilter(emptySet(), emptySet(), null)
+
+                renderFilterResolution(filter) shouldBe emptyList()
+            }
+
+            test("lists the expanded releases") {
+                val filter = VulnlogFilter(setOf(Release("1.0.0"), Release("1.1.0")), emptySet(), null)
+
+                renderFilterResolution(filter) shouldBe
+                    listOf("release filter expanded to releases: 1.0.0, 1.1.0")
+            }
+
+            test("lists the matched tags") {
+                val filter = VulnlogFilter(emptySet(), setOf(Tag("internal")), null)
+
+                renderFilterResolution(filter) shouldBe listOf("tag filter matched tags: internal")
+            }
+
+            test("renders the canonical reporter name") {
+                val filter = VulnlogFilter(emptySet(), emptySet(), ReporterType.CARGO_AUDIT)
+
+                renderFilterResolution(filter) shouldBe listOf("reporter filter: cargo-audit")
+            }
+
+            test("renders all active dimensions in order") {
+                val filter = VulnlogFilter(setOf(Release("1.0.0")), setOf(Tag("internal")), ReporterType.TRIVY)
+
+                renderFilterResolution(filter) shouldBe
+                    listOf(
+                        "release filter expanded to releases: 1.0.0",
+                        "tag filter matched tags: internal",
+                        "reporter filter: trivy",
+                    )
+            }
+        }
+    })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/ParseFileTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/ParseFileTest.kt
@@ -1,0 +1,68 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.shell
+
+import dev.vulnlog.lib.core.parsed
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+
+private val MINIMAL_YAML =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        analysis: not reachable
+        verdict: not affected
+        justification: vulnerable code not in execute path
+    """.trimIndent()
+
+class ParseFileTest :
+    FunSpec({
+
+        context("renderParsedInputs") {
+
+            test("states the schema version and entry counts") {
+                val input = FileInputOption.File(Path.of("test.vl.yaml"))
+
+                val lines = renderParsedInputs(mapOf(input to parsed(MINIMAL_YAML)))
+
+                lines shouldBe
+                    listOf(
+                        "parsed test.vl.yaml: schema version 1, releases: 1, tags: 0, vulnerabilities: 1",
+                    )
+            }
+
+            test("sorts lines by file name") {
+                val second = FileInputOption.File(Path.of("b.vl.yaml"))
+                val first = FileInputOption.File(Path.of("a.vl.yaml"))
+                val ok = parsed(MINIMAL_YAML)
+
+                val lines = renderParsedInputs(mapOf(second to ok, first to ok))
+
+                lines.map { it.substringBefore(":") } shouldBe listOf("parsed a.vl.yaml", "parsed b.vl.yaml")
+            }
+
+            test("renders nothing for an empty map") {
+                renderParsedInputs(emptyMap()) shouldBe emptyList()
+            }
+        }
+    })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/ValidateFileTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/shell/ValidateFileTest.kt
@@ -1,0 +1,69 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.shell
+
+import dev.vulnlog.lib.result.Rule
+import dev.vulnlog.lib.result.Severity
+import dev.vulnlog.lib.result.ValidationFinding
+import dev.vulnlog.lib.result.ValidationResult
+import dev.vulnlog.lib.result.ValidationResults
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+
+private fun finding(severity: Severity) =
+    ValidationFinding(
+        severity = severity,
+        rule = Rule.DANGLING_TAG_REFERENCE,
+        path = "vulnerabilities[CVE-2026-1234].tags",
+        message = "tag not defined",
+    )
+
+private fun resultsFor(vararg fileToFindings: Pair<String, List<ValidationFinding>>) =
+    ValidationResults(
+        fileToFindings.associate { (name, findings) ->
+            FileInputOption.File(Path.of(name)) to ValidationResult(findings)
+        },
+    )
+
+class ValidateFileTest :
+    FunSpec({
+
+        context("renderValidationSummary") {
+
+            test("renders no findings for a clean file") {
+                renderValidationSummary(resultsFor("clean.vl.yaml" to emptyList())) shouldBe
+                    listOf("validated clean.vl.yaml: no findings")
+            }
+
+            test("renders the counts per severity, omitting empty severities") {
+                val results =
+                    resultsFor(
+                        "app.vl.yaml" to
+                            listOf(
+                                finding(Severity.ERROR),
+                                finding(Severity.WARNING),
+                                finding(Severity.WARNING),
+                            ),
+                    )
+
+                renderValidationSummary(results) shouldBe
+                    listOf("validated app.vl.yaml: 1 error(s), 2 warning(s)")
+            }
+
+            test("renders one sorted line per file") {
+                val results =
+                    resultsFor(
+                        "b.vl.yaml" to emptyList(),
+                        "a.vl.yaml" to listOf(finding(Severity.INFO)),
+                    )
+
+                renderValidationSummary(results) shouldBe
+                    listOf(
+                        "validated a.vl.yaml: 1 info(s)",
+                        "validated b.vl.yaml: no findings",
+                    )
+            }
+        }
+    })


### PR DESCRIPTION
- The Logging.md guideline helps to apply the correct log level and explains the logging concept
- CLI: New `-v` and `-vv` flag for verbose and debug log output
- Gradle plugin reuses the Gradle's `--info` and `--debug` flags