### PR TITLE
feat: Add GitHub Action for CI integration

### DIFF
--- a/.github/workflows/gh-action-test.yaml
+++ b/.github/workflows/gh-action-test.yaml
@@ -1,0 +1,40 @@
+name: GitHub Action Test
+
+on:
+  pull_request:
+    paths:
+      - gh-action/**
+      - .github/workflows/gh-action-test.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run action (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run Vulnlog
+        id: vulnlog
+        uses: ./gh-action
+
+      - name: Verify generated files
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.vulnlog.outputs.report-file }}
+        run: |
+          for file in .snyk .trivyignore.yaml "$REPORT_FILE"; do
+            if [ ! -f "$file" ]; then
+              echo "::error::expected file missing: $file"
+              exit 1
+            fi
+          done

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,18 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Generate suppression files
-        run: |
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/work" \
-            ghcr.io/${{ github.repository }}:0.14.0 \
-            suppress vulnlog.yaml --output-dir /work
-
-      - name: Ensure suppression files exist
-        run: |
-          [ -f .snyk ] || touch .snyk
-          [ -f .trivyignore.yaml ] || touch .trivyignore.yaml
+      - name: Run Vulnlog
+        id: vulnlog
+        uses: ./gh-action
 
       - name: Upload suppression files
         uses: actions/upload-artifact@v7
@@ -39,19 +30,11 @@ jobs:
             .snyk
             .trivyignore.yaml
 
-      - name: Generate HTML report
-        run: |
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/work" \
-            ghcr.io/${{ github.repository }}:0.14.0 \
-            report vulnlog.yaml
-
       - name: Upload HTML report
         uses: actions/upload-artifact@v7
         with:
           name: reports
-          path: vulnlog-report.html
+          path: ${{ steps.vulnlog.outputs.report-file }}
 
   snyk:
     name: Snyk Open Source

--- a/docs/modules/ROOT/pages/guides/run-in-ci.adoc
+++ b/docs/modules/ROOT/pages/guides/run-in-ci.adoc
@@ -13,6 +13,9 @@ See xref:reference/gradle-plugin.adoc[Gradle Plugin] for details.
 
 == GitHub Actions
 
+The Vulnlog GitHub Action downloads the CLI and generates suppression files and the HTML report in a single step.
+It runs on Linux, macOS, and Windows runners and does not require Docker.
+
 Example workflow using dynamic suppression. The suppression file is generated, used by the scanner, and discarded after the pipeline completes:
 
 [source,yaml,subs="attributes"]
@@ -23,19 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate suppression files
-        continue-on-error: true
-        run: |
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/work" \
-            -w /work \
-            ghcr.io/vulnlog/vulnlog:{vulnlog-version} \
-            suppress --reporter trivy vulnlog.yaml --output-dir /work
-
-      - name: Ensure suppression file exists
-        run: |
-          [ -f .trivyignore.yaml ] || touch .trivyignore.yaml
+      - name: Run Vulnlog
+        id: vulnlog
+        uses: vulnlog/vulnlog/gh-action@v{vulnlog-version}
+        with:
+          reporter: trivy
+          ensure-files: .trivyignore.yaml
 
       - name: Run Trivy scan
         uses: aquasecurity/trivy-action@master
@@ -52,23 +48,15 @@ jobs:
           sarif_file: trivy-results.sarif
           category: trivy
 
-      - name: Generate Vulnlog HTML report
-        if: always()
-        run: |
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/work" \
-            -w /work \
-            ghcr.io/vulnlog/vulnlog:{vulnlog-version} \
-            report vulnlog.yaml -o /work
-
       - name: Upload Vulnlog HTML report
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: vulnerability-report
-          path: vulnlog-report.html
+          path: ${{ steps.vulnlog.outputs.report-file }}
 ----
+
+The action creates missing suppression files empty, so scanners always find their file, even before the first suppression exists.
+See the https://github.com/vulnlog/vulnlog/tree/main/gh-action[action README] for all inputs and outputs.
 
 == Using the Docker image
 

--- a/gh-action/README.md
+++ b/gh-action/README.md
@@ -1,0 +1,59 @@
+# Vulnlog GitHub Action
+
+Run [Vulnlog](https://vulnlog.dev) in your GitHub Actions workflows. The action downloads the Vulnlog CLI and generates scanner suppression files and an HTML vulnerability report from your Vulnlog file, all in a single step.
+
+## Usage
+
+With a `vulnlog.yaml` in the repository root, no configuration is needed:
+
+```yaml
+- name: Run Vulnlog
+  uses: vulnlog/vulnlog/gh-action@v0.17.0
+```
+
+This generates suppression files for every reporter in your Vulnlog file and writes an HTML report to `vulnlog-report.html`. Suppression files that would otherwise be missing, for example when no vulnerability is suppressed yet, are created empty so scanners always find them.
+
+A typical dynamic suppression setup generates the files right before the scanner runs:
+
+```yaml
+- name: Run Vulnlog
+  uses: vulnlog/vulnlog/gh-action@v0.17.0
+  with:
+    reporter: trivy
+    ensure-files: .trivyignore.yaml
+
+- name: Run Trivy scan
+  uses: aquasecurity/trivy-action@0.36.0
+  with:
+    scan-type: fs
+    scan-ref: .
+    trivyignores: .trivyignore.yaml
+```
+
+## Inputs
+
+| Input | Default | Description |
+| ----- | ------- | ----------- |
+| `version` | current release | Vulnlog CLI version to download, matching a [released version](https://github.com/vulnlog/vulnlog/releases). |
+| `file` | `vulnlog.yaml` | Path to the Vulnlog file. |
+| `suppress` | `true` | Generate suppression files. |
+| `report` | `true` | Generate the HTML report. |
+| `output-dir` | `.` | Directory the suppression files are written to. |
+| `report-output` | `vulnlog-report.html` | File path the HTML report is written to. |
+| `format` | `auto` | Suppression file format. `auto` uses each reporter's native format, `generic` forces the generic Vulnlog JSON format. |
+| `release` | | Only include vulnerabilities up to and including this release. |
+| `tags` | | Comma-separated list of tags to filter on. |
+| `reporter` | | Only include reports from this reporter. |
+| `ensure-files` | `.snyk .trivyignore.yaml` | Space-separated file names created empty in `output-dir` when suppression generates no file for them. Set to an empty string to disable. |
+
+## Outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `report-file` | Path of the generated HTML report, ready for `actions/upload-artifact`. |
+
+## Requirements
+
+The action runs on GitHub-hosted `ubuntu`, `macos`, and `windows` runners, and on self-hosted runners with matching platforms (`linux/amd64`, `macos/aarch64`, `windows/amd64`). Docker is not required.
+
+The action is available from Vulnlog 0.17.0 on. Pin it to a release tag of this repository; the tag also selects the default CLI version.

--- a/gh-action/action.yml
+++ b/gh-action/action.yml
@@ -1,0 +1,159 @@
+name: Vulnlog
+description: Generate scanner suppression files and a vulnerability report from a Vulnlog file.
+
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  version:
+    description: Vulnlog CLI version to download, matching a released version.
+    required: false
+    # Bump together with vulnlog-version in docs/antora.yml during release preparation.
+    default: "0.16.0"
+  file:
+    description: Path to the Vulnlog file.
+    required: false
+    default: vulnlog.yaml
+  suppress:
+    description: Generate suppression files ('true' or 'false').
+    required: false
+    default: "true"
+  report:
+    description: Generate the HTML report ('true' or 'false').
+    required: false
+    default: "true"
+  output-dir:
+    description: Directory the suppression files are written to.
+    required: false
+    default: "."
+  report-output:
+    description: File path the HTML report is written to.
+    required: false
+    default: vulnlog-report.html
+  format:
+    description: Suppression file format, 'auto' or 'generic'.
+    required: false
+    default: auto
+  release:
+    description: Only include vulnerabilities up to and including this release.
+    required: false
+    default: ""
+  tags:
+    description: Comma-separated list of tags to filter on.
+    required: false
+    default: ""
+  reporter:
+    description: Only include reports from this reporter.
+    required: false
+    default: ""
+  ensure-files:
+    description: >-
+      Space-separated file names created empty in output-dir when suppression
+      generates no file for them. Set to an empty string to disable.
+    required: false
+    default: ".snyk .trivyignore.yaml"
+
+outputs:
+  report-file:
+    description: Path of the generated HTML report.
+    value: ${{ steps.report.outputs.report-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Vulnlog
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        case "$RUNNER_OS-$RUNNER_ARCH" in
+          Linux-X64) asset=vulnlog-linux-amd64 ;;
+          macOS-ARM64) asset=vulnlog-macos-aarch64 ;;
+          Windows-X64) asset=vulnlog-windows-amd64 ;;
+          *)
+            echo "::error::unsupported runner platform: $RUNNER_OS $RUNNER_ARCH"
+            exit 1
+            ;;
+        esac
+        install_dir="$RUNNER_TEMP/vulnlog-cli"
+        archive="$RUNNER_TEMP/$asset.zip"
+        mkdir -p "$install_dir"
+        curl -fsSL --retry 3 \
+          "https://github.com/vulnlog/vulnlog/releases/download/v$VERSION/$asset.zip" \
+          -o "$archive"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          "$SYSTEMROOT/System32/tar.exe" -xf "$archive" -C "$install_dir"
+        else
+          unzip -oq "$archive" -d "$install_dir"
+          chmod +x "$install_dir/vulnlog"
+        fi
+        "$install_dir/vulnlog" --version
+        echo "$install_dir" >> "$GITHUB_PATH"
+
+    - name: Generate suppression files
+      if: ${{ inputs.suppress == 'true' }}
+      shell: bash
+      env:
+        FILE: ${{ inputs.file }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+        FORMAT: ${{ inputs.format }}
+        FILTER_RELEASE: ${{ inputs.release }}
+        FILTER_TAGS: ${{ inputs.tags }}
+        FILTER_REPORTER: ${{ inputs.reporter }}
+      run: |
+        args=(suppress "$FILE" --output-dir "$OUTPUT_DIR" --format "$FORMAT")
+        if [ -n "$FILTER_RELEASE" ]; then
+          args+=(--release "$FILTER_RELEASE")
+        fi
+        if [ -n "$FILTER_REPORTER" ]; then
+          args+=(--reporter "$FILTER_REPORTER")
+        fi
+        IFS=', ' read -ra tags <<< "$FILTER_TAGS"
+        for tag in "${tags[@]}"; do
+          if [ -n "$tag" ]; then
+            args+=(--tags "$tag")
+          fi
+        done
+        vulnlog "${args[@]}"
+
+    - name: Ensure suppression files exist
+      if: ${{ inputs.suppress == 'true' && inputs.ensure-files != '' }}
+      shell: bash
+      env:
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+        ENSURE_FILES: ${{ inputs.ensure-files }}
+      run: |
+        for file in $ENSURE_FILES; do
+          path="$OUTPUT_DIR/$file"
+          if [ ! -f "$path" ]; then
+            touch "$path"
+          fi
+        done
+
+    - name: Generate report
+      id: report
+      if: ${{ inputs.report == 'true' }}
+      shell: bash
+      env:
+        FILE: ${{ inputs.file }}
+        REPORT_OUTPUT: ${{ inputs.report-output }}
+        FILTER_RELEASE: ${{ inputs.release }}
+        FILTER_TAGS: ${{ inputs.tags }}
+        FILTER_REPORTER: ${{ inputs.reporter }}
+      run: |
+        args=(report "$FILE" --output "$REPORT_OUTPUT")
+        if [ -n "$FILTER_RELEASE" ]; then
+          args+=(--release "$FILTER_RELEASE")
+        fi
+        if [ -n "$FILTER_REPORTER" ]; then
+          args+=(--reporter "$FILTER_REPORTER")
+        fi
+        IFS=', ' read -ra tags <<< "$FILTER_TAGS"
+        for tag in "${tags[@]}"; do
+          if [ -n "$tag" ]; then
+            args+=(--tags "$tag")
+          fi
+        done
+        vulnlog "${args[@]}"
+        echo "report-file=$REPORT_OUTPUT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #64.

## What

Adds a reusable composite action under `gh-action/` that downloads the Vulnlog CLI native binary for the runner platform and generates suppression files and the HTML report in one step:

```yaml
- name: Run Vulnlog
  uses: vulnlog/vulnlog/gh-action@v0.17.0
```

- Task-oriented API: `suppress` and `report` run by default, each toggleable; inputs for file path, CLI `version`, output locations, `format`, and the `release`/`tags`/`reporter` filters; `report-file` output for upload steps.
- The empty-file fallback (`ensure-files`, default `.snyk .trivyignore.yaml`) is built in, so scanners always find their files even before the first suppression exists.
- Runs on `ubuntu`, `macos`, and `windows` runners (linux-amd64, macos-aarch64, windows-amd64 release assets); no Docker required.

## Also in this PR

- `security.yml` dogfoods the action: the two `docker run` steps and the touch fallback collapse into one step, removing the stale hardcoded `0.14.0` image pin.
- New `gh-action-test.yaml` workflow runs the action against this repo's own `vulnlog.yaml` on all three runner OSes and asserts the generated files exist.
- The run-in-ci guide now shows the action as the GitHub Actions path; Docker instructions remain for other CI systems.
- The default CLI version in `action.yml` carries a comment to bump it together with `vulnlog-version` in `docs/antora.yml` during release preparation.

## Verified

- Install, suppress, ensure-files, and report step logic executed locally verbatim against this repo's `vulnlog.yaml` with the released 0.16.0 binary (all expected files produced, filters and fallback behave as designed).
- `actionlint` clean on both workflows; `bash -n` clean on all embedded scripts.
- The PR's own test workflow covers the 3-OS matrix.

## Follow-ups (out of scope)

- Extract to a dedicated `vulnlog/vulnlog-action` repository for Marketplace listing and the `@v1` tag proposed in #64.
- Publish SHA-256 checksums with releases and verify them in the action (also benefits `install.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)