### PR TITLE
docs: Add GitHub Action setup guide and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Or pull the Docker image:
 docker pull ghcr.io/vulnlog/vulnlog:latest
 ```
 
+On a GitHub Actions runner, install the CLI with the
+[Setup Vulnlog CLI](https://github.com/marketplace/actions/setup-vulnlog-cli) action:
+
+```yaml
+- uses: vulnlog/setup-vulnlog@v1
+  with:
+    version: <version>
+```
+
 To integrate Vulnlog into a Gradle build, add the plugin:
 
 ```kotlin

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -41,6 +41,7 @@
 *** xref:reference/cli-add.adoc[modify add]
 *** xref:reference/cli-copy.adoc[modify copy]
 ** xref:reference/gradle-plugin.adoc[Gradle plugin]
+** xref:reference/github-action.adoc[GitHub Action]
 ** xref:reference/exit-codes-and-messages.adoc[Exit codes and messages]
 * Troubleshooting
 ** xref:troubleshooting.adoc[Troubleshooting]

--- a/docs/modules/ROOT/pages/get-started/install.adoc
+++ b/docs/modules/ROOT/pages/get-started/install.adoc
@@ -148,6 +148,21 @@ cd vulnlog
 
 The resulting distribution is placed in `build/install/vulnlog`.
 
+== GitHub Actions
+
+On a GitHub Actions runner, the Setup Vulnlog CLI action installs the CLI and puts it on `PATH`:
+
+[source,yaml,subs="attributes"]
+----
+- name: Set up Vulnlog CLI
+  uses: vulnlog/setup-vulnlog@v1
+  with:
+    version: {vulnlog-version}
+----
+
+Every later step in the job calls `vulnlog` directly.
+The xref:reference/github-action.adoc[GitHub Action reference] documents the inputs, outputs, and supported runners.
+
 == Gradle plugin
 
 For Gradle-based builds, the Vulnlog Gradle plugin runs Vulnlog as part of the build instead of as a separate binary:

--- a/docs/modules/ROOT/pages/guides/run-in-ci.adoc
+++ b/docs/modules/ROOT/pages/guides/run-in-ci.adoc
@@ -13,7 +13,11 @@ See xref:reference/gradle-plugin.adoc[Gradle Plugin] for details.
 
 == GitHub Actions
 
-Example workflow using dynamic suppression. The suppression file is generated, used by the scanner, and discarded after the pipeline completes:
+The https://github.com/marketplace/actions/setup-vulnlog-cli[Setup Vulnlog CLI] action installs the CLI on the runner and puts it on `PATH`.
+Install it once per job, every later step calls `vulnlog` directly.
+
+Example workflow using dynamic suppression.
+The suppression file is generated, used by the scanner, and discarded after the pipeline completes:
 
 [source,yaml,subs="attributes"]
 ----
@@ -23,15 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Vulnlog CLI
+        uses: vulnlog/setup-vulnlog@v1
+        with:
+          version: {vulnlog-version}
+
       - name: Generate suppression files
         continue-on-error: true
-        run: |
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/work" \
-            -w /work \
-            ghcr.io/vulnlog/vulnlog:{vulnlog-version} \
-            suppress --reporter trivy vulnlog.yaml --output-dir /work
+        run: vulnlog suppress --reporter trivy vulnlog.yaml
 
       - name: Ensure suppression file exists
         run: |
@@ -54,13 +57,7 @@ jobs:
 
       - name: Generate Vulnlog HTML report
         if: always()
-        run: |
-          docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "${{ github.workspace }}:/work" \
-            -w /work \
-            ghcr.io/vulnlog/vulnlog:{vulnlog-version} \
-            report impact vulnlog.yaml
+        run: vulnlog report impact vulnlog.yaml
 
       - name: Upload Vulnlog HTML report
         if: always()
@@ -70,9 +67,13 @@ jobs:
           path: vulnlog-impact-report.html
 ----
 
+Pin the `version` input so the pipeline does not change when a new Vulnlog release ships.
+See xref:reference/github-action.adoc[GitHub Action] for the inputs, outputs, and supported runners.
+
 == Using the Docker image
 
-In most CI environments (GitHub Actions, Jenkins, GitLab CI) the runner's workspace is owned by UID 1000, so the container works without extra flags:
+On CI systems without a Vulnlog integration, run the container image.
+In most CI environments (Jenkins, GitLab CI, GitHub Actions) the runner's workspace is owned by UID 1000, so the container works without extra flags:
 
 [source,bash,subs="attributes"]
 ----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -22,6 +22,6 @@ Answer a customer or user from the recorded decision instead of re-analysing: xr
 
 == Returning readers
 
-* Reference: xref:reference/file-format.adoc[The Vulnlog file format], xref:reference/cli.adoc[the CLI], and xref:reference/gradle-plugin.adoc[the Gradle plugin].
+* Reference: xref:reference/file-format.adoc[The Vulnlog file format], xref:reference/cli.adoc[the CLI], xref:reference/gradle-plugin.adoc[the Gradle plugin], and xref:reference/github-action.adoc[the GitHub Action].
 * Concepts: xref:concepts/why-git.adoc[why decisions live in git], xref:concepts/data-model.adoc[the data model], and xref:concepts/vulnerability-states.adoc[vulnerability states].
 * Stuck? Ask in the https://github.com/vulnlog/vulnlog/discussions[GitHub discussions].

--- a/docs/modules/ROOT/pages/reference/github-action.adoc
+++ b/docs/modules/ROOT/pages/reference/github-action.adoc
@@ -1,0 +1,112 @@
+= GitHub Action
+
+The Setup Vulnlog CLI action installs the Vulnlog CLI on a GitHub Actions runner and puts it on `PATH`.
+Install it once per job, every later step calls `vulnlog` directly.
+
+The action is published on the https://github.com/marketplace/actions/setup-vulnlog-cli[GitHub Marketplace] and developed at https://github.com/vulnlog/setup-vulnlog[vulnlog/setup-vulnlog].
+
+== Usage
+
+[source,yaml,subs="attributes"]
+----
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Set up Vulnlog CLI
+    uses: vulnlog/setup-vulnlog@v1
+    with:
+      version: {vulnlog-version}
+
+  - run: vulnlog validate vulnlog.yaml --strict
+
+  - run: vulnlog report impact vulnlog.yaml
+----
+
+The action needs no token and no `permissions` block.
+It only downloads public release assets from GitHub.
+
+== Inputs
+
+[cols="1,1,3"]
+|===
+| Input | Default | Description
+
+| `version`
+| `latest`
+| Version to install, for example `{vulnlog-version}` or `v{vulnlog-version}`. `latest` resolves the newest stable release and never selects a pre-release.
+|===
+
+Pin `version` in every pipeline you rely on.
+`latest` picks up a new release the moment it ships, which suits a nightly job and not a release pipeline.
+
+== Outputs
+
+[cols="1,3"]
+|===
+| Output | Description
+
+| `version`
+| The installed version, without the leading `v`.
+
+| `distribution`
+| `native` or `jvm`.
+
+| `path`
+| Absolute path to the `vulnlog` executable.
+
+| `cache-hit`
+| `true` when the version came from the runner tool cache and nothing was downloaded.
+|===
+
+== Runner support
+
+The action installs the native binary where one exists, and the JVM distribution everywhere else.
+
+[cols="2,1,1"]
+|===
+| Runner | Distribution | Java required
+
+| `ubuntu-latest`, `ubuntu-24.04` (x64)
+| native
+| No
+
+| `macos-latest`, `macos-14` and later (arm64)
+| native
+| No
+
+| `windows-latest` (x64)
+| native
+| No
+
+| `ubuntu-24.04-arm` (arm64)
+| jvm
+| Yes
+
+| `macos-15-intel` (Intel x64)
+| jvm
+| Yes
+|===
+
+On a runner without a native build, install Java 21 or later first.
+Otherwise the step fails and tells you to:
+
+[source,yaml]
+----
+- uses: actions/setup-java@v6
+  with:
+    distribution: temurin
+    java-version: '21'
+
+- uses: vulnlog/setup-vulnlog@v1
+----
+
+[NOTE]
+====
+Vulnlog releases do not yet publish checksums or build attestations, so the action cannot verify the download.
+It will verify by default once they are published.
+====
+
+== See also
+
+* xref:guides/run-in-ci.adoc[Run Vulnlog in CI pipelines] shows a complete workflow.
+* xref:reference/cli.adoc[The Vulnlog CLI] documents the commands to run after the setup step.

--- a/website/index.html
+++ b/website/index.html
@@ -251,8 +251,8 @@
                 </div>
                 <div class="card">
                     <h3>Runs where you build</h3>
-                    <p>Ship a single binary with no runtime dependencies, or integrate Vulnlog as a Gradle plugin. Also
-                        available as a JVM distribution or Docker image.</p>
+                    <p>Ship a single binary with no runtime dependencies, or integrate Vulnlog as a Gradle plugin or a
+                        GitHub Action. Also available as a JVM distribution or Docker image.</p>
                 </div>
             </div>
         </div>
@@ -282,6 +282,15 @@
                     <div class="code-block" id="install-docker"></div>
                     <script id="install-docker-src" type="text/plain">
                         docker pull ghcr.io/vulnlog/vulnlog:VULNLOG_VERSION
+                    </script>
+                </div>
+                <div class="install-option">
+                    <h3>GitHub Actions</h3>
+                    <div class="code-block" id="install-action"></div>
+                    <script id="install-action-src" type="text/plain">
+                        - uses: vulnlog/setup-vulnlog@v1
+                          with:
+                            version: VULNLOG_VERSION
                     </script>
                 </div>
                 <div class="install-option">
@@ -517,6 +526,7 @@
     renderExample('install-script', 'install-script-src', highlightPlain);
     renderExample('install-brew', 'install-brew-src', highlightPlain);
     renderExample('install-docker', 'install-docker-src', highlightPlain);
+    renderExample('install-action', 'install-action-src', highlightPlain);
     renderExample('install-gradle', 'install-gradle-src', highlightPlain);
 </script>
 


### PR DESCRIPTION
- Documented the `setup-vulnlog` GitHub Action for CLI installation.
- Updated CI examples, website, and navigation with the new integration.
- Added a dedicated reference page for the GitHub Action.

Fix #64