### PR TITLE
feat: Add VEX command with minimal OpenVEX output file

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -40,6 +40,7 @@
 *** xref:reference/cli-report-changelog.adoc[report changelog]
 *** xref:reference/cli-add.adoc[modify add]
 *** xref:reference/cli-copy.adoc[modify copy]
+*** xref:reference/cli-vex-openvex.adoc[vex openvex]
 ** xref:reference/gradle-plugin.adoc[Gradle plugin]
 ** xref:reference/github-action.adoc[GitHub Action]
 ** xref:reference/exit-codes-and-messages.adoc[Exit codes and messages]

--- a/docs/modules/ROOT/pages/reference/cli-vex-openvex.adoc
+++ b/docs/modules/ROOT/pages/reference/cli-vex-openvex.adoc
@@ -1,0 +1,186 @@
+= vulnlog vex openvex
+
+Generates an https://github.com/openvex/spec[OpenVEX] document from a Vulnlog file.
+VEX (Vulnerability Exploitability eXchange) tells a scanner which findings do not apply to your product, so consumers of your release can filter their own scan results with your triage.
+
+[source]
+----
+vulnlog vex openvex <file> [-o <path>]
+----
+
+The document covers every release that declares `purls`.
+Filtering, release scoping and document identity across runs are not available yet; see <<not-yet-available>>.
+
+[cols="2,3"]
+|===
+| Flag | Description
+
+| `-o, --output <path>`
+| Output file path, or `-` to write to stdout.
+Defaults to `vex.json` in the current directory.
+
+| `-`
+| Use as the file argument to read from stdin.
+
+|===
+
+== What the document contains
+
+The document carries the fields the OpenVEX specification requires, and one statement per vulnerability entry and release.
+
+`author` is the project `author`, with `contact` in parentheses when the file records one.
+`version` is always `1`, and `@id` is a fresh identifier on every run: without a baseline to continue from, each run issues a new document.
+
+Each statement names the vulnerability by its entry `id`, the products it applies to, and the status.
+
+=== Products come from release purls
+
+The products of a statement are the `purls` of the release, not the `packages` of the vulnerability entry.
+`packages` names the vulnerable dependency, which OpenVEX models as a subcomponent; subcomponents are not written yet.
+
+A release that declares no `purls` has nothing to anchor a statement to, so it is left out and named in a warning.
+When that leaves no statement at all, the command fails rather than write a document the specification rejects.
+
+See xref:reference/project-and-releases.adoc[Project and releases] for how to declare `purls`.
+
+=== Status
+
+[cols="1,3"]
+|===
+| Status | When
+
+| `not_affected`
+| The entry's verdict is `not affected`. The statement carries the matching OpenVEX `justification`.
+
+| `affected`
+| The entry's verdict is `affected`. The statement carries an `action_statement` derived from the `disposition` and the fix release.
+
+| `fixed`
+| The release is the one named by `resolution.in`.
+
+| `under_investigation`
+| The entry has no verdict yet.
+|===
+
+`fixed` wins: a release listed under `releases` and named by `resolution.in` at the same time is reported as fixed.
+
+The action statement is derived, never copied from `analysis`:
+
+[cols="1,1,2"]
+|===
+| `disposition` | Fix release | `action_statement`
+
+| _(absent)_
+| yes
+| `Update to release <id>.` followed by the resolution `note`
+
+| _(absent)_
+| no
+| `No remediation is available yet.`
+
+| `will fix`
+| yes
+| `Update to release <id>.` followed by the resolution `note`
+
+| `will fix`
+| no
+| `A fix is planned but not yet available.`
+
+| `wont fix`
+| yes
+| `The risk is accepted for this release. A fix ships with release <id>.`
+
+| `wont fix`
+| no
+| `The risk is accepted. No fix is planned.`
+|===
+
+The resolution note is appended to update actions only, so a note can never soften an accepted risk.
+
+== Examples
+
+.Write the document to vex.json
+[source]
+----
+vulnlog vex openvex vulnlog.yaml
+Wrote: vex.json
+----
+
+.Write the document to stdout
+[source]
+----
+vulnlog vex openvex full-example.vl.yaml -o -
+warning: releases without purls are not part of the document: '8.1.2'
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://vulnlog.dev/vex/8fce68a8-f9eb-483d-8b7d-19cb626826f7",
+  "author": "Demo Security Team (security@demo.com)",
+  "timestamp": "2026-09-04T11:29:56Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2021-002"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/demo-project@8.1.1"
+        },
+        {
+          "@id": "pkg:generic/demo-project@8.1.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-44228"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/demo-project@8.1.1"
+        },
+        {
+          "@id": "pkg:generic/demo-project@8.1.1"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to release 8.1.2. Updated Log4J from 2.14.1 to 2.17.1"
+    }
+  ]
+}
+----
+
+.Filter scanner findings with the generated document
+[source]
+----
+vulnlog vex openvex vulnlog.yaml -o vex.json
+trivy image --vex vex.json demo-project:8.1.1
+----
+
+Only `not_affected` and `fixed` statements remove a finding.
+`affected` and `under_investigation` leave the finding in place.
+
+[[not-yet-available]]
+== Not yet available
+
+* Scoping the document to one release, or to the purls carrying a given tag.
+* Continuing an existing document's identity, so `@id` stays stable and `version` counts up.
+* Subcomponents, vulnerability aliases and descriptions, statement timestamps, and the analysis text.
+* A Gradle task.
+
+== When the command fails
+
+* The Vulnlog file fails validation: the command reports the findings and exits `2`.
+* No statement applies, because no release declares `purls` or no entry references a release that does: the command exits `2`.
+  OpenVEX requires at least one statement, so no file is written.
+
+See xref:reference/exit-codes-and-messages.adoc[Exit codes and messages] for the full table.
+
+== See also
+
+- xref:reference/project-and-releases.adoc[Project and releases] for declaring release purls
+- xref:reference/verdicts-and-justifications.adoc[Verdicts and justifications] for the justification vocabulary
+- xref:reference/cli-suppress.adoc[vulnlog suppress] for scanners that read ignore files instead of VEX
+- xref:reference/exit-codes-and-messages.adoc[Exit codes and messages]

--- a/docs/modules/ROOT/pages/reference/cli-vex-openvex.adoc
+++ b/docs/modules/ROOT/pages/reference/cli-vex-openvex.adoc
@@ -168,7 +168,6 @@ Only `not_affected` and `fixed` statements remove a finding.
 * Scoping the document to one release, or to the purls carrying a given tag.
 * Continuing an existing document's identity, so `@id` stays stable and `version` counts up.
 * Subcomponents, vulnerability aliases and descriptions, statement timestamps, and the analysis text.
-* A Gradle task.
 
 == When the command fails
 

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -97,6 +97,9 @@ Available on `report` and `suppress` commands.
 
 | xref:reference/cli-copy.adoc[modify copy]
 | Copy vulnerability entries from one Vulnlog file into one or more others.
+
+| xref:reference/cli-vex-openvex.adoc[vex openvex]
+| Generate an OpenVEX document for the releases that declare purls.
 |===
 
 == Exit codes

--- a/docs/modules/ROOT/pages/reference/gradle-plugin.adoc
+++ b/docs/modules/ROOT/pages/reference/gradle-plugin.adoc
@@ -35,6 +35,9 @@ vulnlog {
 
 | `report`
 | Container for the report tasks. Each report type has its own nested block: `report { impact { } }` and `report { changelog { } }`.
+
+| `vex`
+| Container for the VEX tasks. Each format has its own nested block: `vex { openvex { } }`.
 |===
 
 == Diagnostics
@@ -334,6 +337,45 @@ It fails the build only on invalid input, for example an unknown `fixedIn` or in
 [source,shell]
 ----
 ./gradlew vulnlogChangelogReport
+----
+
+=== `vulnlogOpenVex`
+
+Generates an OpenVEX document from a single Vulnlog file.
+See xref:reference/cli-vex-openvex.adoc[`vulnlog vex openvex`] for the document contents and for which entries it leaves out.
+
+Settings live under `vex { openvex { } }`.
+
+[source,kotlin]
+----
+vulnlog {
+    vex {
+        openvex {
+            outputFile.set(layout.buildDirectory.file("vulnlog/vex.json"))  // optional
+        }
+    }
+}
+----
+
+[cols="2,2,3"]
+|===
+| Property | Default | Description
+
+| `outputFile`
+| `build/vulnlog/vex.json`
+| File where the document is written.
+|===
+
+Only one input file is supported, since a document is anchored on the purls of one project.
+The task fails when `files` holds more than one entry.
+
+It also fails when no statement applies, either because no release declares purls or because no vulnerability entry references a release that does.
+Releases without purls are left out of the document and named in a `warning:` line.
+
+.Example
+[source,shell]
+----
+./gradlew vulnlogOpenVex
 ----
 
 === `VulnlogCopyTask`

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/Main.kt
@@ -34,6 +34,7 @@ fun vulnlogCommand(): VulnlogCli =
         .subcommands(SuppressCommand())
         .subcommands(ReportCommand())
         .subcommands(ModifyCommand())
+        .subcommands(VexCommand())
 
 internal fun runVulnlog(
     cli: VulnlogCli,

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/OpenVexCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/OpenVexCommand.kt
@@ -1,0 +1,123 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.parameters.arguments.ArgumentTransformContext
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.OptionCallTransformContext
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import dev.vulnlog.cli.shell.validation.validateInputOrFail
+import dev.vulnlog.lib.core.formatHint
+import dev.vulnlog.lib.core.formatMessage
+import dev.vulnlog.lib.core.vex.openvex.buildOpenVexDocument
+import dev.vulnlog.lib.core.vex.openvex.releasesWithoutPurls
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexProducts
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexSkippedEntries
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexStatementCounts
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexWritten
+import dev.vulnlog.lib.model.ReleaseEntry
+import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.model.finding.FindingSeverity
+import dev.vulnlog.lib.parse.vex.openvex.OpenVexWriter
+import dev.vulnlog.lib.shell.FileInputOption
+import dev.vulnlog.lib.shell.FileOutputOption
+import java.nio.file.Path
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+private const val DOCUMENT_ID_PREFIX = "https://vulnlog.dev/vex/"
+
+class OpenVexCommand : CliktCommand(name = "openvex") {
+    override fun help(context: Context): String = "Generate OpenVEX files from Vulnlog files."
+
+    override fun helpEpilog(context: Context): String =
+        """
+        |Examples:
+        |
+        |Write the document to vex.json in the current directory.
+        |
+        |vulnlog vex openvex vulnlog.yaml
+        |
+        |Write the document to stdout.
+        |
+        |vulnlog vex openvex vulnlog.yaml -o -
+        """.trimMargin()
+
+    val input: FileInputOption by argument(
+        help = "Vulnlog file, or '-' to read from stdin.",
+    ).convert(conversion = ArgumentTransformContext::toInputFileOption)
+
+    val output: FileOutputOption by option(
+        "-o",
+        "--output",
+        metavar = "<path>",
+        help = "Output file path, or '-' to write to stdout. Defaults to vex.json in the current directory.",
+    ).convert(conversion = OptionCallTransformContext::toOutputFileOption)
+        .default(FileOutputOption.File(Path.of("vex.json")))
+
+    override fun run() {
+        val vulnlogFile = validateInputOrFail(input).project.vulnlogProjectFile
+
+        warnAboutSkippedReleases(vulnlogFile)
+        renderOpenVexProducts(vulnlogFile)?.let { diagnosticSink().verbose(it) }
+        val document =
+            buildOpenVexDocument(
+                vulnlogFile = vulnlogFile,
+                id = DOCUMENT_ID_PREFIX + UUID.randomUUID(),
+                timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            )
+        renderOpenVexSkippedEntries(vulnlogFile).forEach { diagnosticSink().debug(it) }
+        if (document.statements.isEmpty()) failOnEmptyDocument(vulnlogFile)
+        diagnosticSink().verbose(renderOpenVexStatementCounts(document))
+
+        val content = OpenVexWriter.write(document)
+        when (val target = output) {
+            is FileOutputOption.File -> {
+                writeReport({ echoStatus(it) }, { echoMessage(it) }, target, content)
+                diagnosticSink().verbose(renderOpenVexWritten(target.path.toString(), document))
+            }
+            FileOutputOption.Stdout -> {
+                echo(content, trailingNewline = false)
+                diagnosticSink().verbose(renderOpenVexWritten("<stdout>", document))
+            }
+        }
+    }
+
+    /** Names the releases a statement was meant for that carry no purl, because they silently drop out. */
+    private fun warnAboutSkippedReleases(vulnlogFile: VulnlogFile) {
+        val skipped =
+            vulnlogFile.vulnerabilities
+                .flatMap { vulnEntry -> releasesWithoutPurls(vulnlogFile, vulnEntry) }
+                .toSet()
+        if (skipped.isEmpty()) return
+        // Named in the order the file declares them, not the order the entries happen to mention them.
+        val names =
+            vulnlogFile.releases
+                .map(ReleaseEntry::id)
+                .filter { it in skipped }
+                .joinToString(", ") { "'${it.value}'" }
+        echoMessage(
+            formatMessage(FindingSeverity.WARNING, "releases without purls are not part of the document: $names"),
+        )
+    }
+
+    private fun failOnEmptyDocument(vulnlogFile: VulnlogFile): Nothing {
+        echoMessage(formatMessage(FindingSeverity.ERROR, "no statement applies"))
+        val hint =
+            if (vulnlogFile.releases.none { it.purls.isNotEmpty() }) {
+                "declare 'purls' on the releases you want the document to cover"
+            } else {
+                "no vulnerability entry references a release that declares purls"
+            }
+        echoMessage(formatHint(hint))
+        throw ProgramResult(ExitCode.VALIDATION_ERROR.code)
+    }
+}

--- a/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/VexCommand.kt
+++ b/modules/cli-app/src/main/kotlin/dev/vulnlog/cli/shell/VexCommand.kt
@@ -1,0 +1,23 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.subcommands
+
+class VexCommand : CliktCommand(name = "vex") {
+    override fun help(context: Context): String =
+        "Generate Vulnerability Exploitability eXchange (VEX) files from Vulnlog files."
+
+    init {
+        subcommands(
+            OpenVexCommand(),
+        )
+    }
+
+    override val invokeWithoutSubcommand: Boolean = true
+
+    override fun run() = requireSubcommand()
+}

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/MainTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/MainTest.kt
@@ -94,6 +94,18 @@ class MainTest :
                 }.first shouldBe ExitCode.GENERAL_ERROR.code
             }
 
+            test("vex alone is a usage error") {
+                withCapturedStdout {
+                    runVulnlog(vulnlogCommand(), listOf("vex"))
+                }.first shouldBe ExitCode.GENERAL_ERROR.code
+            }
+
+            test("vex lists the VEX formats it can generate") {
+                val (_, out) = withCapturedStdout { runVulnlog(vulnlogCommand(), listOf("vex")) }
+
+                out shouldContain "openvex"
+            }
+
             test("report lists the reports it can generate") {
                 val (_, out) = withCapturedStdout { runVulnlog(vulnlogCommand(), listOf("report")) }
 

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/OpenVexCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/OpenVexCommandTest.kt
@@ -4,6 +4,7 @@
 package dev.vulnlog.cli.shell
 
 import com.github.ajalt.clikt.testing.test
+import dev.vulnlog.lib.fixtures.openVexDocument
 import dev.vulnlog.lib.fixtures.vulnlogDocument
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -15,7 +16,7 @@ class OpenVexCommandTest :
         context("happy path") {
 
             test("writes the document to stdout and warns about the release without purls") {
-                withTempFile(content = vulnlogYamlWithPurls()) { input ->
+                withTempFile(content = openVexDocument()) { input ->
                     val result = OpenVexCommand().test("${input.absolutePath} -o -")
 
                     result.statusCode shouldBe 0
@@ -28,7 +29,7 @@ class OpenVexCommandTest :
             }
 
             test("-o writes the document to the given path") {
-                withTempFile(content = vulnlogYamlWithPurls()) { input ->
+                withTempFile(content = openVexDocument()) { input ->
                     withTempDir(prefix = "openvex-out") { outputDir ->
                         val target = outputDir.resolve("vex.json")
 

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/OpenVexCommandTest.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/OpenVexCommandTest.kt
@@ -1,0 +1,57 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.cli.shell
+
+import com.github.ajalt.clikt.testing.test
+import dev.vulnlog.lib.fixtures.vulnlogDocument
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class OpenVexCommandTest :
+    FunSpec({
+
+        context("happy path") {
+
+            test("writes the document to stdout and warns about the release without purls") {
+                withTempFile(content = vulnlogYamlWithPurls()) { input ->
+                    val result = OpenVexCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe 0
+                    result.stdout shouldContain "\"@context\": \"https://openvex.dev/ns/v0.2.0\""
+                    result.stdout shouldContain "\"@id\": \"pkg:maven/com.acme/acme-web-app@1.0.0\""
+                    result.stdout shouldContain "\"status\": \"not_affected\""
+                    result.stderr shouldContain
+                        "warning: releases without purls are not part of the document: '1.0.1'"
+                }
+            }
+
+            test("-o writes the document to the given path") {
+                withTempFile(content = vulnlogYamlWithPurls()) { input ->
+                    withTempDir(prefix = "openvex-out") { outputDir ->
+                        val target = outputDir.resolve("vex.json")
+
+                        val result = OpenVexCommand().test("${input.absolutePath} -o ${target.toAbsolutePath()}")
+
+                        result.statusCode shouldBe 0
+                        result.stderr shouldContain "Wrote: ${target.toAbsolutePath()}"
+                        target.toFile().readText() shouldContain "\"version\": 1"
+                    }
+                }
+            }
+        }
+
+        context("nothing to write") {
+
+            test("fails when no release declares purls") {
+                withTempFile(content = vulnlogDocument()) { input ->
+                    val result = OpenVexCommand().test("${input.absolutePath} -o -")
+
+                    result.statusCode shouldBe ExitCode.VALIDATION_ERROR.code
+                    result.stderr shouldContain "error: no statement applies"
+                    result.stderr shouldContain "declare 'purls' on the releases"
+                }
+            }
+        }
+    })

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
@@ -83,6 +83,43 @@ internal fun vulnlogYamlWithPendingFix(
     """.trimIndent()
 
 /**
+ * Builds a Vulnlog YAML with one release that declares purls and one that does not, so an OpenVEX
+ * document has both a product to anchor to and a release it must skip.
+ */
+internal fun vulnlogYamlWithPurls(): String =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: Acme Web App
+      author: Acme Corp Security Team
+      contact: security@acme.example
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+        purls:
+          - purl: "pkg:maven/com.acme/acme-web-app@1.0.0"
+      - id: 1.0.1
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        analysis: not reachable
+        verdict: not affected
+        justification: vulnerable code not in execute path
+        resolution:
+          in: 1.0.1
+    """.trimIndent()
+
+/**
  * Builds a Vulnlog YAML whose only report uses the `other` reporter, which is not suppressible
  * — used to exercise the empty-output path of suppress.
  */

--- a/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
+++ b/modules/cli-app/src/test/kotlin/dev/vulnlog/cli/shell/TestSupport.kt
@@ -83,43 +83,6 @@ internal fun vulnlogYamlWithPendingFix(
     """.trimIndent()
 
 /**
- * Builds a Vulnlog YAML with one release that declares purls and one that does not, so an OpenVEX
- * document has both a product to anchor to and a release it must skip.
- */
-internal fun vulnlogYamlWithPurls(): String =
-    """
-    ---
-    schemaVersion: "1"
-
-    project:
-      organization: Acme Corp
-      name: Acme Web App
-      author: Acme Corp Security Team
-      contact: security@acme.example
-
-    releases:
-      - id: 1.0.0
-        published_at: 2026-01-15
-        purls:
-          - purl: "pkg:maven/com.acme/acme-web-app@1.0.0"
-      - id: 1.0.1
-
-    vulnerabilities:
-
-      - id: CVE-2026-1234
-        releases: [ 1.0.0 ]
-        description: Remote code execution in example-lib
-        packages: [ "pkg:npm/example-lib@2.3.0" ]
-        reports:
-          - reporter: trivy
-        analysis: not reachable
-        verdict: not affected
-        justification: vulnerable code not in execute path
-        resolution:
-          in: 1.0.1
-    """.trimIndent()
-
-/**
  * Builds a Vulnlog YAML whose only report uses the `other` reporter, which is not suppressible
  * — used to exercise the empty-output path of suppress.
  */

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogExtension.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogExtension.kt
@@ -30,6 +30,9 @@ abstract class VulnlogExtension
         val report: VulnlogReportExtension =
             objects.newInstance(VulnlogReportExtension::class.java)
 
+        val vex: VulnlogVexExtension =
+            objects.newInstance(VulnlogVexExtension::class.java)
+
         val fmt: VulnlogFmtExtension =
             objects.newInstance(VulnlogFmtExtension::class.java).apply {
                 check.convention(false)
@@ -40,6 +43,8 @@ abstract class VulnlogExtension
         fun suppress(action: Action<VulnlogSuppressExtension>) = action.execute(suppress)
 
         fun report(action: Action<VulnlogReportExtension>) = action.execute(report)
+
+        fun vex(action: Action<VulnlogVexExtension>) = action.execute(vex)
 
         fun fmt(action: Action<VulnlogFmtExtension>) = action.execute(fmt)
     }
@@ -95,4 +100,18 @@ interface VulnlogChangelogReportExtension {
     val reporter: Property<String>
     val asOf: Property<String>
     val tags: SetProperty<String>
+}
+
+abstract class VulnlogVexExtension
+    @Inject
+    constructor(
+        objects: ObjectFactory,
+    ) {
+        val openvex: VulnlogOpenVexExtension = objects.newInstance(VulnlogOpenVexExtension::class.java)
+
+        fun openvex(action: Action<VulnlogOpenVexExtension>) = action.execute(openvex)
+    }
+
+interface VulnlogOpenVexExtension {
+    val outputFile: RegularFileProperty
 }

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogOpenVexTask.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogOpenVexTask.kt
@@ -1,0 +1,99 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.gradle
+
+import dev.vulnlog.gradle.internal.diagnosticSink
+import dev.vulnlog.gradle.internal.singleVulnlogFileInput
+import dev.vulnlog.gradle.validation.validateInputOrFail
+import dev.vulnlog.lib.core.StatusVerb
+import dev.vulnlog.lib.core.formatMessage
+import dev.vulnlog.lib.core.formatStatus
+import dev.vulnlog.lib.core.vex.openvex.buildOpenVexDocument
+import dev.vulnlog.lib.core.vex.openvex.releasesWithoutPurls
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexProducts
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexSkippedEntries
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexStatementCounts
+import dev.vulnlog.lib.core.vex.openvex.renderOpenVexWritten
+import dev.vulnlog.lib.model.ReleaseEntry
+import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.model.finding.FindingSeverity
+import dev.vulnlog.lib.parse.vex.openvex.OpenVexWriter
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+private const val DOCUMENT_ID_PREFIX = "https://vulnlog.dev/vex/"
+
+@CacheableTask
+abstract class VulnlogOpenVexTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val files: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val sink = diagnosticSink()
+        val inputFile = singleVulnlogFileInput(name, files.files)
+        val vulnlogFile = validateInputOrFail(inputFile).project.vulnlogProjectFile
+
+        warnAboutSkippedReleases(vulnlogFile)
+        renderOpenVexProducts(vulnlogFile)?.let(sink::verbose)
+        val document =
+            buildOpenVexDocument(
+                vulnlogFile = vulnlogFile,
+                id = DOCUMENT_ID_PREFIX + UUID.randomUUID(),
+                timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            )
+        renderOpenVexSkippedEntries(vulnlogFile).forEach(sink::debug)
+        if (document.statements.isEmpty()) failOnEmptyDocument(vulnlogFile)
+        sink.verbose(renderOpenVexStatementCounts(document))
+
+        val out = outputFile.get().asFile
+        out.parentFile?.mkdirs()
+        out.writeText(OpenVexWriter.write(document))
+        sink.verbose(renderOpenVexWritten(out.path, document))
+        logger.lifecycle(formatStatus(StatusVerb.WROTE, out.absolutePath))
+    }
+
+    /** Names the releases a statement was meant for that carry no purl, because they silently drop out. */
+    private fun warnAboutSkippedReleases(vulnlogFile: VulnlogFile) {
+        val skipped =
+            vulnlogFile.vulnerabilities
+                .flatMap { vulnEntry -> releasesWithoutPurls(vulnlogFile, vulnEntry) }
+                .toSet()
+        if (skipped.isEmpty()) return
+        // Named in the order the file declares them, not the order the entries happen to mention them.
+        val names =
+            vulnlogFile.releases
+                .map(ReleaseEntry::id)
+                .filter { it in skipped }
+                .joinToString(", ") { "'${it.value}'" }
+        logger.warn(
+            formatMessage(FindingSeverity.WARNING, "releases without purls are not part of the document: $names"),
+        )
+    }
+
+    private fun failOnEmptyDocument(vulnlogFile: VulnlogFile): Nothing {
+        val hint =
+            if (vulnlogFile.releases.none { it.purls.isNotEmpty() }) {
+                "Declare 'purls' on the releases you want the document to cover."
+            } else {
+                "No vulnerability entry references a release that declares purls."
+            }
+        throw GradleException("No statement applies. $hint")
+    }
+}

--- a/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogPlugin.kt
+++ b/modules/gradle-plugin/src/main/kotlin/dev/vulnlog/gradle/VulnlogPlugin.kt
@@ -82,6 +82,16 @@ class VulnlogPlugin : Plugin<Project> {
                 changelog.outputFile.orElse(task.format.map { token -> project.changelogReportFile(token) }),
             )
         }
+
+        project.tasks.register("vulnlogOpenVex", VulnlogOpenVexTask::class.java) { task ->
+            task.description = "Generate an OpenVEX document."
+            task.group = "vulnlog"
+            task.files.from(extension.files)
+            task.outputFile.convention(
+                extension.vex.openvex.outputFile
+                    .orElse(project.layout.buildDirectory.file("vulnlog/vex.json")),
+            )
+        }
     }
 }
 

--- a/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogOpenVexTaskTest.kt
+++ b/modules/gradle-plugin/src/test/kotlin/dev/vulnlog/gradle/VulnlogOpenVexTaskTest.kt
@@ -1,0 +1,132 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.gradle
+
+import dev.vulnlog.lib.fixtures.openVexDocument
+import dev.vulnlog.lib.fixtures.vulnlogDocument
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.gradle.testkit.runner.TaskOutcome
+
+private val FILES_FROM_TEST_YAML =
+    buildFile(
+        """
+        vulnlog {
+            files.from("test.vl.yaml")
+        }
+        """.trimIndent(),
+    )
+
+/** Wraps [settings] in a `vex { openvex { } }` block on a single input file. */
+private fun openVexBuildFile(settings: String) =
+    buildFile(
+        """
+        vulnlog {
+            files.from("test.vl.yaml")
+            vex {
+                openvex {
+                    $settings
+                }
+            }
+        }
+        """.trimIndent(),
+    )
+
+class VulnlogOpenVexTaskTest :
+    FunSpec({
+
+        context("happy path") {
+
+            test("writes the document to the default output file") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to openVexDocument())
+
+                val result = runner(dir, "vulnlogOpenVex").build()
+
+                result.task(":vulnlogOpenVex")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.output shouldContain "Wrote: "
+                val document = dir.resolve("build/vulnlog/vex.json").readText()
+                document shouldContain "\"@context\": \"https://openvex.dev/ns/v0.2.0\""
+                document shouldContain "\"@id\": \"pkg:maven/com.acme/acme-web-app@1.0.0\""
+                document shouldContain "\"status\": \"not_affected\""
+            }
+
+            test("writes the document to the configured output file") {
+                val dir =
+                    gradleProject(
+                        openVexBuildFile("""outputFile = layout.projectDirectory.file("openvex.json")"""),
+                        "test.vl.yaml" to openVexDocument(),
+                    )
+
+                val result = runner(dir, "vulnlogOpenVex").build()
+
+                result.task(":vulnlogOpenVex")?.outcome shouldBe TaskOutcome.SUCCESS
+                dir.resolve("openvex.json").readText() shouldContain "\"version\": 1"
+            }
+
+            test("warns about the release without purls") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to openVexDocument())
+
+                val result = runner(dir, "vulnlogOpenVex").build()
+
+                result.output shouldContain "warning: releases without purls are not part of the document: '1.0.1'"
+            }
+        }
+
+        context("nothing to write") {
+
+            test("fails when no release declares purls") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to vulnlogDocument())
+
+                val result = runner(dir, "vulnlogOpenVex").buildAndFail()
+
+                result.task(":vulnlogOpenVex")?.outcome shouldBe TaskOutcome.FAILED
+                result.output shouldContain "No statement applies."
+                result.output shouldContain "Declare 'purls' on the releases"
+            }
+        }
+
+        context("input validation") {
+
+            test("fails when no Vulnlog file is configured") {
+                val dir = gradleProject(buildFile())
+
+                val result = runner(dir, "vulnlogOpenVex").buildAndFail()
+
+                result.output shouldContain "No Vulnlog files configured"
+            }
+
+            test("fails when more than one Vulnlog file is configured") {
+                val dir =
+                    gradleProject(
+                        buildFile(
+                            """
+                            vulnlog {
+                                files.from("a.vl.yaml", "b.vl.yaml")
+                            }
+                            """.trimIndent(),
+                        ),
+                        "a.vl.yaml" to openVexDocument(),
+                        "b.vl.yaml" to openVexDocument(projectName = "Other App"),
+                    )
+
+                val result = runner(dir, "vulnlogOpenVex").buildAndFail()
+
+                result.task(":vulnlogOpenVex")?.outcome shouldBe TaskOutcome.FAILED
+                result.output shouldContain "vulnlogOpenVex supports a single Vulnlog file, but 2 are configured."
+            }
+        }
+
+        context("up-to-date checking") {
+
+            test("skips the task when nothing changed") {
+                val dir = gradleProject(FILES_FROM_TEST_YAML, "test.vl.yaml" to openVexDocument())
+                runner(dir, "vulnlogOpenVex").build()
+
+                val result = runner(dir, "vulnlogOpenVex").build()
+
+                result.task(":vulnlogOpenVex")?.outcome shouldBe TaskOutcome.UP_TO_DATE
+            }
+        }
+    })

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/vex/Vex.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/vex/Vex.kt
@@ -1,0 +1,71 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core.vex
+
+import dev.vulnlog.lib.core.findDisposition
+import dev.vulnlog.lib.model.Disposition
+import dev.vulnlog.lib.model.Release
+import dev.vulnlog.lib.model.Verdict
+import dev.vulnlog.lib.model.VulnerabilityEntry
+import dev.vulnlog.lib.model.vex.VexStatus
+
+/**
+ * Resolves the [VexStatus] of [vulnEntry] for one [release]. The release named by the resolution is fixed, whatever
+ * the verdict says; every other release follows the verdict.
+ */
+fun deriveVexStatus(
+    vulnEntry: VulnerabilityEntry,
+    release: Release,
+): VexStatus =
+    when {
+        vulnEntry.resolution?.release == release -> VexStatus.Fixed
+        else -> deriveUnresolvedStatus(vulnEntry)
+    }
+
+private fun deriveUnresolvedStatus(vulnEntry: VulnerabilityEntry): VexStatus =
+    when (val verdict = vulnEntry.verdict) {
+        Verdict.UnderInvestigation -> VexStatus.UnderInvestigation
+        is Verdict.NotAffected -> VexStatus.NotAffected(verdict.justification)
+        is Verdict.Affected -> VexStatus.Affected(vexActionStatement(vulnEntry))
+    }
+
+/**
+ * Derives the action a consumer of an affected product should take.
+ *
+ * The text follows from the disposition and the fix release, never from the analysis.
+ * The resolution note is appended to update actions only, so a note can never soften an accepted risk.
+ */
+fun vexActionStatement(vulnEntry: VulnerabilityEntry): String {
+    val fixRelease = vulnEntry.resolution?.release
+    return when (findDisposition(vulnEntry.verdict)) {
+        Disposition.WONT_FIX ->
+            if (fixRelease == null) {
+                "The risk is accepted. No fix is planned."
+            } else {
+                "The risk is accepted for this release. A fix ships with release ${fixRelease.value}."
+            }
+
+        Disposition.WILL_FIX ->
+            if (fixRelease == null) {
+                "A fix is planned but not yet available."
+            } else {
+                updateAction(vulnEntry)
+            }
+
+        null ->
+            if (fixRelease == null) {
+                "No remediation is available yet."
+            } else {
+                updateAction(vulnEntry)
+            }
+    }
+}
+
+// TODO the resolution.note field is primarily for internal use and describes: "Brief description of how the vulnerability was resolved"
+// This is not relevant for consumers of the VEX document. Re-think this approach but leave it for now.
+private fun updateAction(vulnEntry: VulnerabilityEntry): String {
+    val resolution = vulnEntry.resolution ?: error("update action requires a resolution")
+    val update = "Update to release ${resolution.release.value}."
+    return resolution.note?.takeIf(String::isNotBlank)?.let { note -> "$update $note" } ?: update
+}

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/vex/openvex/OpenVex.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/vex/openvex/OpenVex.kt
@@ -1,0 +1,108 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core.vex.openvex
+
+import dev.vulnlog.lib.core.vex.deriveVexStatus
+import dev.vulnlog.lib.model.Project
+import dev.vulnlog.lib.model.Purl
+import dev.vulnlog.lib.model.Release
+import dev.vulnlog.lib.model.ReleaseEntry
+import dev.vulnlog.lib.model.VexJustification
+import dev.vulnlog.lib.model.VulnerabilityEntry
+import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.model.vex.VexStatus
+import dev.vulnlog.lib.model.vex.openvex.OpenVexDocument
+import dev.vulnlog.lib.model.vex.openvex.OpenVexStatement
+import java.time.Instant
+
+/** The OpenVEX specification this writer emits. */
+const val OPEN_VEX_CONTEXT: String = "https://openvex.dev/ns/v0.2.0"
+
+/**
+ * Builds the OpenVEX document for [vulnlogFile]. The document [id] and [timestamp] are passed in so the function stays
+ * pure and its output byte-stable for a given input.
+ */
+fun buildOpenVexDocument(
+    vulnlogFile: VulnlogFile,
+    id: String,
+    timestamp: Instant,
+): OpenVexDocument =
+    OpenVexDocument(
+        id = id,
+        author = openVexAuthor(vulnlogFile.project),
+        timestamp = timestamp,
+        version = 1,
+        statements = collectOpenVexStatements(vulnlogFile),
+    )
+
+/**
+ * Collects one statement per vulnerability entry and release, anchored to that release's purls.
+ * A release without purls carries no product and is therefore left out; identical statements collapse, and the result
+ * is ordered so the same input always writes the same bytes.
+ */
+fun collectOpenVexStatements(vulnlogFile: VulnlogFile): List<OpenVexStatement> {
+    val purlsByRelease: Map<Release, List<Purl>> =
+        vulnlogFile.releases
+            .associateBy(ReleaseEntry::id) { entry -> entry.purls.map { it.purl }.sortedBy(Purl::value) }
+    return vulnlogFile.vulnerabilities
+        .flatMap { vulnEntry -> statementsOf(vulnEntry, purlsByRelease) }
+        .distinct()
+        .sortedWith(compareBy({ it.vulnerability.id }, { it.products.joinToString(",", transform = Purl::value) }))
+}
+
+/** The releases [vulnEntry] speaks about that declare no purls, so a caller can name them in a warning. */
+fun releasesWithoutPurls(
+    vulnlogFile: VulnlogFile,
+    vulnEntry: VulnerabilityEntry,
+): List<Release> {
+    val withPurls =
+        vulnlogFile.releases
+            .filter { it.purls.isNotEmpty() }
+            .map(ReleaseEntry::id)
+            .toSet()
+    return coveredReleases(vulnEntry).filterNot { it in withPurls }
+}
+
+/** The author line of the document: the project author, with the contact in parentheses when one is recorded. */
+fun openVexAuthor(project: Project): String =
+    project.contact?.let { contact -> "${project.author} ($contact)" } ?: project.author
+
+/** The OpenVEX token for a [VexStatus]. */
+fun openVexStatus(status: VexStatus): String =
+    when (status) {
+        VexStatus.UnderInvestigation -> "under_investigation"
+        VexStatus.Fixed -> "fixed"
+        is VexStatus.NotAffected -> "not_affected"
+        is VexStatus.Affected -> "affected"
+    }
+
+/** The OpenVEX token for a [VexJustification]. */
+fun openVexJustification(justification: VexJustification): String =
+    when (justification) {
+        VexJustification.COMPONENT_NOT_PRESENT -> "component_not_present"
+        VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST -> "inline_mitigations_already_exist"
+        VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY ->
+            "vulnerable_code_cannot_be_controlled_by_adversary"
+
+        VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH -> "vulnerable_code_not_in_execute_path"
+        VexJustification.VULNERABLE_CODE_NOT_PRESENT -> "vulnerable_code_not_present"
+    }
+
+private fun statementsOf(
+    vulnEntry: VulnerabilityEntry,
+    purlsByRelease: Map<Release, List<Purl>>,
+): List<OpenVexStatement> =
+    coveredReleases(vulnEntry).mapNotNull { release ->
+        purlsByRelease[release]?.takeIf { it.isNotEmpty() }?.let { products ->
+            OpenVexStatement(
+                vulnerability = vulnEntry.id,
+                products = products,
+                status = deriveVexStatus(vulnEntry, release),
+            )
+        }
+    }
+
+/** The releases an entry makes a statement about: the ones it affects, plus the one that fixed it. */
+fun coveredReleases(vulnEntry: VulnerabilityEntry): List<Release> =
+    (vulnEntry.releases + listOfNotNull(vulnEntry.resolution?.release)).distinct()

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/vex/openvex/OpenVexRenderer.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/core/vex/openvex/OpenVexRenderer.kt
@@ -1,0 +1,62 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core.vex.openvex
+
+import dev.vulnlog.lib.model.VulnerabilityEntry
+import dev.vulnlog.lib.model.VulnlogFile
+import dev.vulnlog.lib.model.vex.openvex.OpenVexDocument
+
+/**
+ * Renders one diagnostic line naming the releases that anchor the document and how many purls each contributes,
+ * or null when no release declares one. Shared by the CLI and the Gradle plugin.
+ */
+fun renderOpenVexProducts(vulnlogFile: VulnlogFile): String? {
+    val anchors = vulnlogFile.releases.filter { it.purls.isNotEmpty() }
+    if (anchors.isEmpty()) return null
+    val detail = anchors.joinToString(", ") { "'${it.id.value}' (${pluralize(it.purls.size, "purl")})" }
+    return "anchored on ${pluralize(anchors.size, "release")} with purls: $detail"
+}
+
+/** Renders one diagnostic line stating how many statements the document holds, broken down by status. */
+fun renderOpenVexStatementCounts(document: OpenVexDocument): String {
+    val byStatus =
+        document.statements
+            .groupingBy { openVexStatus(it.status) }
+            .eachCount()
+    val detail = byStatus.entries.sortedBy { it.key }.joinToString(", ") { "${it.value} ${it.key}" }
+    return "collected ${pluralize(document.statements.size, "statement")}: $detail"
+}
+
+/**
+ * Renders one diagnostic line per vulnerability entry that contributed no statement, stating why.
+ * These are the entries missing from the document, so this is the line to read when one is expected and absent.
+ */
+fun renderOpenVexSkippedEntries(vulnlogFile: VulnlogFile): List<String> =
+    vulnlogFile.vulnerabilities.mapNotNull { vulnEntry -> skipReason(vulnlogFile, vulnEntry) }.sorted()
+
+/** Renders one diagnostic line for a written document, the counterpart of the suppression writer's. */
+fun renderOpenVexWritten(
+    target: String,
+    document: OpenVexDocument,
+): String = "wrote $target: openvex format, ${pluralize(document.statements.size, "statement")}"
+
+private fun skipReason(
+    vulnlogFile: VulnlogFile,
+    vulnEntry: VulnerabilityEntry,
+): String? {
+    val covered = coveredReleases(vulnEntry)
+    val withoutPurls = releasesWithoutPurls(vulnlogFile, vulnEntry)
+    return when {
+        covered.isEmpty() -> "skipped ${vulnEntry.id.id}: it references no release"
+        covered.size == withoutPurls.size ->
+            "skipped ${vulnEntry.id.id}: no release it applies to declares purls"
+
+        else -> null
+    }
+}
+
+private fun pluralize(
+    count: Int,
+    noun: String,
+): String = if (count == 1) "1 $noun" else "$count ${noun}s"

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/vex/VexStatus.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/vex/VexStatus.kt
@@ -1,0 +1,28 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.model.vex
+
+import dev.vulnlog.lib.model.VexJustification
+
+/**
+ * The status of one vulnerability in one product, shared by every VEX format.
+ * Each variant carries the field its status requires, so a statement missing a mandatory field cannot be built.
+ */
+sealed interface VexStatus {
+    /** Not yet triaged. */
+    data object UnderInvestigation : VexStatus
+
+    /** The vulnerability was remediated in this product. */
+    data object Fixed : VexStatus
+
+    /** The vulnerable component is present but the product is not impacted. */
+    data class NotAffected(
+        val justification: VexJustification,
+    ) : VexStatus
+
+    /** The vulnerability impacts this product. */
+    data class Affected(
+        val actionStatement: String,
+    ) : VexStatus
+}

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/vex/openvex/OpenVexDocument.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/vex/openvex/OpenVexDocument.kt
@@ -1,0 +1,30 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.model.vex.openvex
+
+import java.time.Instant
+
+/** An OpenVEX document. Holds only what the specification requires, plus the products of each statement. */
+data class OpenVexDocument(
+    /**
+     * Unique identifier of the document. Without a baseline every run mints a new one.
+     */
+    val id: String,
+    /**
+     * Author of the document, taken from the project metadata.
+     */
+    val author: String,
+    /**
+     * Time the document was issued.
+     */
+    val timestamp: Instant,
+    /**
+     * Revision of the document. Always 1 until baselines are supported.
+     */
+    val version: Int,
+    /**
+     * The statements the document makes. The specification requires at least one.
+     */
+    val statements: List<OpenVexStatement>,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/vex/openvex/OpenVexStatement.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/model/vex/openvex/OpenVexStatement.kt
@@ -1,0 +1,24 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.model.vex.openvex
+
+import dev.vulnlog.lib.model.Purl
+import dev.vulnlog.lib.model.VulnId
+import dev.vulnlog.lib.model.vex.VexStatus
+
+/** One statement: what a vulnerability means for a set of release artifacts. */
+data class OpenVexStatement(
+    /**
+     * The vulnerability the statement is about.
+     */
+    val vulnerability: VulnId,
+    /**
+     * The release artifacts the statement applies to.
+     */
+    val products: List<Purl>,
+    /**
+     * The status of the vulnerability in those artifacts.
+     */
+    val status: VexStatus,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/dto/ReleasePurlEntryDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/dto/ReleasePurlEntryDto.kt
@@ -3,7 +3,11 @@
 
 package dev.vulnlog.lib.parse.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 data class ReleasePurlEntryDto(
     val purl: String,
-    val tags: List<String>,
+    // Optional in the schema, and omitted rather than written empty: the schema requires at least one tag when the key is present.
+    @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val tags: List<String> = emptyList(),
 )

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexMapper.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexMapper.kt
@@ -1,0 +1,52 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex
+
+import dev.vulnlog.lib.core.vex.openvex.OPEN_VEX_CONTEXT
+import dev.vulnlog.lib.core.vex.openvex.openVexJustification
+import dev.vulnlog.lib.core.vex.openvex.openVexStatus
+import dev.vulnlog.lib.model.vex.VexStatus
+import dev.vulnlog.lib.model.vex.openvex.OpenVexDocument
+import dev.vulnlog.lib.model.vex.openvex.OpenVexStatement
+import dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexDocumentDto
+import dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexProductDto
+import dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexStatementDto
+import dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexVulnerabilityDto
+import java.time.format.DateTimeFormatter
+
+object OpenVexMapper {
+    fun toDto(document: OpenVexDocument): OpenVexDocumentDto =
+        OpenVexDocumentDto(
+            context = OPEN_VEX_CONTEXT,
+            id = document.id,
+            author = document.author,
+            // Formatted here rather than left to Jackson, whose date handling is version dependent.
+            timestamp = DateTimeFormatter.ISO_INSTANT.format(document.timestamp),
+            version = document.version,
+            statements = document.statements.map(::toStatementDto),
+        )
+
+    private fun toStatementDto(statement: OpenVexStatement): OpenVexStatementDto =
+        OpenVexStatementDto(
+            vulnerability = OpenVexVulnerabilityDto(statement.vulnerability.id),
+            products = statement.products.map { purl -> OpenVexProductDto(purl.value) },
+            status = openVexStatus(statement.status),
+            justification = justificationOf(statement.status),
+            actionStatement = actionStatementOf(statement.status),
+        )
+
+    /** Required for `not_affected`, absent everywhere else. */
+    private fun justificationOf(status: VexStatus): String? =
+        when (status) {
+            is VexStatus.NotAffected -> openVexJustification(status.justification)
+            is VexStatus.Affected, VexStatus.Fixed, VexStatus.UnderInvestigation -> null
+        }
+
+    /** Required for `affected`, absent everywhere else. */
+    private fun actionStatementOf(status: VexStatus): String? =
+        when (status) {
+            is VexStatus.Affected -> status.actionStatement
+            is VexStatus.NotAffected, VexStatus.Fixed, VexStatus.UnderInvestigation -> null
+        }
+}

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexWriter.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexWriter.kt
@@ -1,0 +1,33 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex
+
+import dev.vulnlog.lib.model.vex.openvex.OpenVexDocument
+import tools.jackson.core.util.DefaultIndenter
+import tools.jackson.core.util.DefaultPrettyPrinter
+import tools.jackson.core.util.Separators
+import tools.jackson.databind.SerializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+object OpenVexWriter {
+    // Objects and arrays are indented with two spaces and a plain "\n", never the platform line separator, so the same document writes the same bytes everywhere.
+    private val indenter = DefaultIndenter("  ", "\n")
+
+    private val prettyPrinter =
+        DefaultPrettyPrinter()
+            .withObjectIndenter(indenter)
+            .withArrayIndenter(indenter)
+            .withSeparators(Separators.createDefaultInstance().withObjectNameValueSpacing(Separators.Spacing.AFTER))
+
+    private val mapper =
+        JsonMapper
+            .builder()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .defaultPrettyPrinter(prettyPrinter)
+            .addModule(kotlinModule())
+            .build()
+
+    fun write(document: OpenVexDocument): String = mapper.writeValueAsString(OpenVexMapper.toDto(document)) + "\n"
+}

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexDocumentDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexDocumentDto.kt
@@ -1,0 +1,18 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/** The OpenVEX document as it is serialized. Property order is the emitted key order. */
+data class OpenVexDocumentDto(
+    @param:JsonProperty("@context")
+    val context: String,
+    @param:JsonProperty("@id")
+    val id: String,
+    val author: String,
+    val timestamp: String,
+    val version: Int,
+    val statements: List<OpenVexStatementDto>,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexProductDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexProductDto.kt
@@ -1,0 +1,12 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/** A product a statement applies to, identified by its Package URL. */
+data class OpenVexProductDto(
+    @param:JsonProperty("@id")
+    val id: String,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexStatementDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexStatementDto.kt
@@ -1,0 +1,21 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * One serialized statement. `justification` is required for `not_affected` and `action_statement` for `affected`; both are absent for every other status.
+ */
+data class OpenVexStatementDto(
+    val vulnerability: OpenVexVulnerabilityDto,
+    val products: List<OpenVexProductDto>,
+    val status: String,
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
+    val justification: String? = null,
+    @param:JsonProperty("action_statement")
+    @param:JsonInclude(JsonInclude.Include.NON_NULL)
+    val actionStatement: String? = null,
+)

--- a/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexVulnerabilityDto.kt
+++ b/modules/lib/src/main/kotlin/dev/vulnlog/lib/parse/vex/openvex/dto/OpenVexVulnerabilityDto.kt
@@ -1,0 +1,9 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex.dto
+
+/** The vulnerability a statement is about. An object since OpenVEX 0.2.0, not a bare string. */
+data class OpenVexVulnerabilityDto(
+    val name: String,
+)

--- a/modules/lib/src/main/resources/META-INF/native-image/dev.vulnlog/lib/reflect-config.json
+++ b/modules/lib/src/main/resources/META-INF/native-image/dev.vulnlog/lib/reflect-config.json
@@ -130,5 +130,29 @@
     "allDeclaredFields": true,
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexDocumentDto",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexStatementDto",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexVulnerabilityDto",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexProductDto",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
   }
 ]

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/vex/VexTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/vex/VexTest.kt
@@ -1,0 +1,111 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core.vex
+
+import dev.vulnlog.lib.fixtures.cve
+import dev.vulnlog.lib.fixtures.release
+import dev.vulnlog.lib.fixtures.resolution
+import dev.vulnlog.lib.fixtures.vulnerability
+import dev.vulnlog.lib.model.Disposition
+import dev.vulnlog.lib.model.Severity
+import dev.vulnlog.lib.model.Verdict
+import dev.vulnlog.lib.model.vex.VexStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+private val affected = Verdict.Affected(Severity.HIGH)
+
+private fun affectedIn(
+    releases: List<String>,
+    disposition: Disposition? = null,
+    fixedIn: String? = null,
+    note: String? = null,
+) = vulnerability(
+    id = cve("CVE-2026-1234"),
+    releases = releases.map(::release),
+    verdict = Verdict.Affected(Severity.HIGH, disposition),
+    resolution = fixedIn?.let { resolution(release = it, note = note) },
+)
+
+class VexTest :
+    FunSpec({
+
+        context("deriveVexStatus") {
+
+            test("the resolution release is fixed even though the verdict says affected") {
+                val entry = affectedIn(releases = listOf("1.0.0"), fixedIn = "1.0.1")
+
+                val status = deriveVexStatus(entry, release("1.0.1"))
+
+                status shouldBe VexStatus.Fixed
+            }
+
+            test("a release other than the resolution release keeps the verdict's status") {
+                val entry = affectedIn(releases = listOf("1.0.0"), fixedIn = "1.0.1")
+
+                val status = deriveVexStatus(entry, release("1.0.0"))
+
+                status.shouldBeInstanceOf<VexStatus.Affected>()
+            }
+        }
+
+        context("vexActionStatement") {
+
+            test("points at the fix release and appends the resolution note") {
+                val entry = affectedIn(releases = listOf("1.0.0"), fixedIn = "1.0.1", note = "Bumped log4j to 2.17.1.")
+
+                val action = vexActionStatement(entry)
+
+                action shouldBe "Update to release 1.0.1. Bumped log4j to 2.17.1."
+            }
+
+            test("points at the fix release alone when no note is recorded") {
+                val entry =
+                    affectedIn(releases = listOf("1.0.0"), disposition = Disposition.WILL_FIX, fixedIn = "1.0.1")
+
+                val action = vexActionStatement(entry)
+
+                action shouldBe "Update to release 1.0.1."
+            }
+
+            test("states that no remediation exists when neither intent nor fix is recorded") {
+                val entry = vulnerability(id = cve("CVE-2026-1234"), verdict = affected)
+
+                val action = vexActionStatement(entry)
+
+                action shouldBe "No remediation is available yet."
+            }
+
+            test("states that a fix is planned for 'will fix' without a resolution") {
+                val entry = affectedIn(releases = listOf("1.0.0"), disposition = Disposition.WILL_FIX)
+
+                val action = vexActionStatement(entry)
+
+                action shouldBe "A fix is planned but not yet available."
+            }
+
+            test("states the accepted risk for 'wont fix' without a resolution") {
+                val entry = affectedIn(releases = listOf("1.0.0"), disposition = Disposition.WONT_FIX)
+
+                val action = vexActionStatement(entry)
+
+                action shouldBe "The risk is accepted. No fix is planned."
+            }
+
+            test("keeps the accepted risk and never appends the note when 'wont fix' has a resolution") {
+                val entry =
+                    affectedIn(
+                        releases = listOf("1.0.0"),
+                        disposition = Disposition.WONT_FIX,
+                        fixedIn = "1.0.1",
+                        note = "Bumped log4j to 2.17.1.",
+                    )
+
+                val action = vexActionStatement(entry)
+
+                action shouldBe "The risk is accepted for this release. A fix ships with release 1.0.1."
+            }
+        }
+    })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/vex/openvex/OpenVexTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/core/vex/openvex/OpenVexTest.kt
@@ -1,0 +1,67 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.core.vex.openvex
+
+import dev.vulnlog.lib.fixtures.cve
+import dev.vulnlog.lib.fixtures.mavenPurlEntry
+import dev.vulnlog.lib.fixtures.release
+import dev.vulnlog.lib.fixtures.releaseEntry
+import dev.vulnlog.lib.fixtures.resolution
+import dev.vulnlog.lib.fixtures.vulnerability
+import dev.vulnlog.lib.fixtures.vulnlogFile
+import dev.vulnlog.lib.model.Severity
+import dev.vulnlog.lib.model.Verdict
+import dev.vulnlog.lib.model.vex.VexStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+private val affectedInV1 =
+    vulnerability(
+        id = cve("CVE-2026-1234"),
+        releases = listOf(release("1.0.0")),
+        verdict = Verdict.Affected(Severity.HIGH),
+        resolution = resolution(release = "1.0.1"),
+    )
+
+class OpenVexTest :
+    FunSpec({
+
+        context("collectOpenVexStatements") {
+
+            test("a release named only by the resolution gets its own fixed statement") {
+                val file =
+                    vulnlogFile(
+                        releases =
+                            listOf(
+                                releaseEntry("1.0.0", purls = listOf(mavenPurlEntry("pkg:maven/com.acme/app@1.0.0"))),
+                                releaseEntry("1.0.1", purls = listOf(mavenPurlEntry("pkg:maven/com.acme/app@1.0.1"))),
+                            ),
+                        vulnerabilities = listOf(affectedInV1),
+                    )
+
+                val statements = collectOpenVexStatements(file)
+
+                val byProduct = statements.associateBy { statement -> statement.products.single().value }
+
+                statements shouldHaveSize 2
+                byProduct.getValue("pkg:maven/com.acme/app@1.0.0").status.shouldBeInstanceOf<VexStatus.Affected>()
+                byProduct.getValue("pkg:maven/com.acme/app@1.0.1").status shouldBe VexStatus.Fixed
+            }
+
+            test("a release without purls produces no statement") {
+                val file =
+                    vulnlogFile(
+                        releases = listOf(releaseEntry("1.0.0"), releaseEntry("1.0.1")),
+                        vulnerabilities = listOf(affectedInV1),
+                    )
+
+                val statements = collectOpenVexStatements(file)
+
+                statements.shouldBeEmpty()
+            }
+        }
+    })

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexGoldenTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexGoldenTest.kt
@@ -1,0 +1,94 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex
+
+import dev.vulnlog.lib.core.vex.openvex.buildOpenVexDocument
+import dev.vulnlog.lib.fixtures.cve
+import dev.vulnlog.lib.fixtures.mavenPurlEntry
+import dev.vulnlog.lib.fixtures.release
+import dev.vulnlog.lib.fixtures.releaseEntry
+import dev.vulnlog.lib.fixtures.resolution
+import dev.vulnlog.lib.fixtures.vulnerability
+import dev.vulnlog.lib.fixtures.vulnlogFile
+import dev.vulnlog.lib.model.Project
+import dev.vulnlog.lib.model.Severity
+import dev.vulnlog.lib.model.Verdict
+import dev.vulnlog.lib.model.VexJustification
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+private const val GOLDEN_RESOURCE = "/vex/golden-openvex.json"
+private val GOLDEN_SOURCE_DIR: Path = Path.of("src/test/resources/vex")
+
+private val releaseV1 = release("1.0.0")
+private val releaseV2 = release("1.0.1")
+
+/**
+ * Pins the bytes of an OpenVEX document covering every status. It guards the `@`-prefixed keys, the
+ * nested vulnerability and product objects, the status and justification vocabulary, key order,
+ * indentation and the trailing newline in one go.
+ */
+class OpenVexGoldenTest :
+    FunSpec({
+
+        test("OpenVEX document matches golden bytes") {
+            val file =
+                vulnlogFile(
+                    project = Project("Acme Corp", "Acme Web App", "Acme Security Team", "security@acme.example"),
+                    releases =
+                        listOf(
+                            releaseEntry(
+                                "1.0.0",
+                                purls =
+                                    listOf(
+                                        mavenPurlEntry("pkg:maven/com.acme/acme-web-app@1.0.0"),
+                                        mavenPurlEntry("pkg:maven/com.acme/acme-cli@1.0.0"),
+                                    ),
+                            ),
+                            releaseEntry("1.0.1", purls = listOf(mavenPurlEntry("pkg:maven/com.acme/acme-cli@1.0.1"))),
+                        ),
+                    vulnerabilities =
+                        listOf(
+                            vulnerability(
+                                id = cve("CVE-2026-1111"),
+                                releases = listOf(releaseV1),
+                                verdict = Verdict.NotAffected(VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH),
+                            ),
+                            vulnerability(
+                                id = cve("CVE-2026-2222"),
+                                releases = listOf(releaseV1),
+                                verdict = Verdict.Affected(Severity.CRITICAL),
+                                resolution = resolution(release = "1.0.1", note = "Bumped log4j to 2.17.1."),
+                            ),
+                            vulnerability(id = cve("CVE-2026-3333"), releases = listOf(releaseV2)),
+                        ),
+                )
+            val document =
+                buildOpenVexDocument(
+                    vulnlogFile = file,
+                    id = "https://vulnlog.dev/vex/3e671687-395b-41f5-a30f-a58921a69b79",
+                    timestamp = Instant.parse("2026-04-25T00:00:00Z"),
+                )
+
+            val actual = OpenVexWriter.write(document)
+
+            actual shouldBe golden(actual)
+        }
+    })
+
+private fun golden(actual: String): String {
+    if (System.getenv("UPDATE_GOLDEN") in listOf("1", "true")) {
+        Files.createDirectories(GOLDEN_SOURCE_DIR)
+        Files.writeString(GOLDEN_SOURCE_DIR.resolve("golden-openvex.json"), actual)
+        return actual
+    }
+    return OpenVexGoldenTest::class.java
+        .getResourceAsStream(GOLDEN_RESOURCE)
+        ?.bufferedReader()
+        ?.use { it.readText() }
+        ?: error("Golden file missing at classpath $GOLDEN_RESOURCE. Run with UPDATE_GOLDEN=1 to create it.")
+}

--- a/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexReflectConfigTest.kt
+++ b/modules/lib/src/test/kotlin/dev/vulnlog/lib/parse/vex/openvex/OpenVexReflectConfigTest.kt
@@ -1,0 +1,68 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.parse.vex.openvex
+
+import dev.vulnlog.lib.parse.vex.openvex.dto.OpenVexDocumentDto
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import java.nio.file.Path
+import java.util.zip.ZipFile
+import kotlin.io.path.isDirectory
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.nameWithoutExtension
+
+private const val DTO_PACKAGE = "dev.vulnlog.lib.parse.vex.openvex.dto"
+private const val REFLECT_CONFIG = "/META-INF/native-image/dev.vulnlog/lib/reflect-config.json"
+
+/**
+ * Jackson reaches the DTOs by reflection, so a DTO the native-image config does not list serializes
+ * to an empty object in the native binary while staying correct on the JVM. This test fails the
+ * moment a DTO is added without registering it.
+ */
+class OpenVexReflectConfigTest :
+    FunSpec({
+
+        test("every OpenVEX DTO is registered for reflection") {
+            val config =
+                OpenVexReflectConfigTest::class.java
+                    .getResourceAsStream(REFLECT_CONFIG)
+                    ?.bufferedReader()
+                    ?.use { it.readText() }
+                    ?: error("Native-image config missing at classpath $REFLECT_CONFIG")
+
+            val unregistered = dtoClassNames().filterNot { name -> config.contains("\"$name\"") }
+
+            unregistered.shouldBeEmpty()
+        }
+    })
+
+/** The compiled DTO classes, read from whatever this test runs against: a classes directory or a jar. */
+private fun dtoClassNames(): List<String> {
+    val location =
+        Path.of(
+            OpenVexDocumentDto::class.java.protectionDomain.codeSource.location
+                .toURI(),
+        )
+    val packagePath = DTO_PACKAGE.replace('.', '/')
+    val simpleNames =
+        if (location.isDirectory()) {
+            location.resolve(packagePath).listDirectoryEntries("*.class").map { it.nameWithoutExtension }
+        } else {
+            ZipFile(location.toFile()).use { jar -> classEntriesUnder(jar, packagePath) }
+        }
+    return simpleNames.filterNot { it.contains('$') }.map { "$DTO_PACKAGE.$it" }.sorted()
+}
+
+private fun classEntriesUnder(
+    jar: ZipFile,
+    packagePath: String,
+): List<String> =
+    jar
+        .entries()
+        .asSequence()
+        .map { it.name }
+        .filter { it.startsWith("$packagePath/") && it.endsWith(".class") }
+        .map { it.removePrefix("$packagePath/").removeSuffix(".class") }
+        .filterNot { it.contains('/') }
+        .toList()

--- a/modules/lib/src/test/resources/vex/golden-openvex.json
+++ b/modules/lib/src/test/resources/vex/golden-openvex.json
@@ -1,0 +1,61 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://vulnlog.dev/vex/3e671687-395b-41f5-a30f-a58921a69b79",
+  "author": "Acme Security Team (security@acme.example)",
+  "timestamp": "2026-04-25T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-1111"
+      },
+      "products": [
+        {
+          "@id": "pkg:maven/com.acme/acme-cli@1.0.0"
+        },
+        {
+          "@id": "pkg:maven/com.acme/acme-web-app@1.0.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-2222"
+      },
+      "products": [
+        {
+          "@id": "pkg:maven/com.acme/acme-cli@1.0.0"
+        },
+        {
+          "@id": "pkg:maven/com.acme/acme-web-app@1.0.0"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to release 1.0.1. Bumped log4j to 2.17.1."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-2222"
+      },
+      "products": [
+        {
+          "@id": "pkg:maven/com.acme/acme-cli@1.0.1"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3333"
+      },
+      "products": [
+        {
+          "@id": "pkg:maven/com.acme/acme-cli@1.0.1"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}

--- a/modules/lib/src/testFixtures/kotlin/dev/vulnlog/lib/fixtures/VexDocuments.kt
+++ b/modules/lib/src/testFixtures/kotlin/dev/vulnlog/lib/fixtures/VexDocuments.kt
@@ -1,0 +1,41 @@
+// Copyright the Vulnlog contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.vulnlog.lib.fixtures
+
+/**
+ * Builds a Vulnlog YAML with one release that declares purls and one that does not, so an OpenVEX
+ * document has both a product to anchor to and a release it must skip.
+ */
+fun openVexDocument(projectName: String = "Acme Web App"): String =
+    """
+    ---
+    schemaVersion: "1"
+
+    project:
+      organization: Acme Corp
+      name: $projectName
+      author: Acme Corp Security Team
+      contact: security@acme.example
+
+    releases:
+      - id: 1.0.0
+        published_at: 2026-01-15
+        purls:
+          - purl: "pkg:maven/com.acme/acme-web-app@1.0.0"
+      - id: 1.0.1
+
+    vulnerabilities:
+
+      - id: CVE-2026-1234
+        releases: [ 1.0.0 ]
+        description: Remote code execution in example-lib
+        packages: [ "pkg:npm/example-lib@2.3.0" ]
+        reports:
+          - reporter: trivy
+        analysis: not reachable
+        verdict: not affected
+        justification: vulnerable code not in execute path
+        resolution:
+          in: 1.0.1
+    """.trimIndent()


### PR DESCRIPTION
The minimal OpenVEX file contains only the required OpenVEX field as of specification level 0.2.

Ref #16 